### PR TITLE
Enable fuzzing

### DIFF
--- a/.boilerplate.txt
+++ b/.boilerplate.txt
@@ -1,0 +1,3 @@
+Distributed under the MIT License.
+See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+SPDX-License-Identifier: MIT

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -20,7 +20,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install Dependencies
         run: |
@@ -31,17 +32,16 @@ jobs:
             "libc++-${CLANG_VERSION}-dev"    \
             "libc++abi-${CLANG_VERSION}-dev"
 
-      - name: Configure Build
+      - name: Configure
         run: |
           mkdir "$BUILD_DIR"
           cmake                                            \
             -S .                                           \
             -B "$BUILD_DIR"                                \
-            -D CMAKE_C_COMPILER="clang-$CLANG_VERSION"     \
-            -D CMAKE_CXX_COMPILER="clang++-$CLANG_VERSION" \
             -D CMAKE_BUILD_TYPE=RelWithDebug               \
+            -D CMAKE_CXX_COMPILER="clang++-$CLANG_VERSION" \
+            -D CMAKE_C_COMPILER="clang-$CLANG_VERSION"     \
             -D URI_FUZZTEST=Yes                            \
-            -D URI_FUZZTEST_MODE=On                        \
             -D URI_LIBCXX=Yes
 
       - name: Build

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   fuzztest:
-    name: Build and Test
+    name: Fuzz Test
     runs-on: ubuntu-latest
     env:
       BUILD_DIR: build_fuzztest
@@ -25,7 +25,11 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-15 cmake libc++-15-dev libc++abi-15-dev
+          sudo apt-get install -y            \
+            "clang-${CLANG_VERSION}"         \
+            cmake                            \
+            "libc++-${CLANG_VERSION}-dev"    \
+            "libc++abi-${CLANG_VERSION}-dev"
 
       - name: Configure Build
         run: |
@@ -37,8 +41,13 @@ jobs:
             -D CMAKE_CXX_COMPILER="clang++-$CLANG_VERSION" \
             -D CMAKE_BUILD_TYPE=RelWithDebug               \
             -D URI_FUZZTEST=Yes                            \
+            -D URI_FUZZTEST_MODE=On                        \
             -D URI_LIBCXX=Yes
 
-      - name: Build and Test
+      - name: Build
         run: |
-            make -C "$BUILD_DIR" -j $(nproc)
+          make -C "$BUILD_DIR" -j "$(nproc)"
+
+      - name: Fuzz
+        run: |
+          "$BUILD_DIR/unittests/uri/unittest" --fuzz_for 10s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option (URI_CXX17 "Use C++17 (rather than C++20)" No)
 option (URI_FUZZTEST "Enable FuzzTest")
-option (URI_FUZZTEST_MODE "The value of FUZZTEST_FUZZING_MODE (ignored unless URI_FUZZTEST is enabled)")
 option (URI_LIBCXX "Use libc++ rather than libstdc++")
 option (URI_WERROR "Compiler warnings are errors")
 
@@ -35,8 +34,8 @@ include (setup_gtest)
 
 set (URI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
-set (FUZZTEST_FUZZING_MODE  ${URI_FUZZTEST_MODE})
 if (URI_FUZZTEST)
+  set (FUZZTEST_FUZZING_MODE On)
   include (FetchContent)
   set (FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")
   message ("Building fuzztest at branch " ${FUZZTEST_REPO_BRANCH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,11 @@
 #===----------------------------------------------------------------------===//
 cmake_minimum_required (VERSION 3.19)
 project (uri CXX)
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option (URI_CXX17 "Use C++17 (rather than C++20)" No)
 option (URI_FUZZTEST "Enable FuzzTest")
+option (URI_FUZZTEST_MODE "The value of FUZZTEST_FUZZING_MODE (ignored unless URI_FUZZTEST is enabled)")
 option (URI_LIBCXX "Use libc++ rather than libstdc++")
 option (URI_WERROR "Compiler warnings are errors")
 
@@ -28,157 +30,29 @@ if (URI_LIBCXX)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif (URI_LIBCXX)
 
-include (CheckCXXCompilerFlag)
-
-# Configure the named target with a standard set of options which enable lots
-# of warnings, select the desired language standard, and so on.
-function (setup_target target)
-  set (
-    clang_options
-    -Weverything
-    -Wno-c++14-extensions
-    -Wno-c++98-compat
-    -Wno-c++98-compat-pedantic
-    -Wno-c99-extensions
-    -Wno-exit-time-destructors
-    -Wno-padded
-    -Wno-undef
-    -Wno-weak-vtables
-  )
-  set (gcc_options -Wall -Wextra -pedantic -Wno-maybe-uninitialized)
-  set (
-    msvc_options
-    -W4 # enable lots of warnings
-    -wd4068 # unknown pragma
-    -wd4324 # structure was padded due to alignment specifier
-  )
-
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    check_cxx_compiler_flag (
-      -Wno-return-std-move-in-c++11 CLANG_RETURN_STD_MOVE_IN_CXX11
-    )
-    if (${CLANG_RETURN_STD_MOVE_IN_CXX11})
-      list (APPEND clang_options -Wno-return-std-move-in-c++11)
-    endif ()
-    check_cxx_compiler_flag (-Wno-c++20-compat CLANG_W_NO_CXX20_COMPAT)
-    if (${CLANG_W_NO_CXX20_COMPAT})
-      list (APPEND clang_options -Wno-c++20-compat)
-    endif ()
-    check_cxx_compiler_flag (-Wno-c++2a-compat CLANG_W_NO_CXX2A_COMPAT)
-    if (${CLANG_W_NO_CXX2A_COMPAT})
-      list (APPEND clang_options -Wno-c++2a-compat)
-    endif ()
-    check_cxx_compiler_flag (
-      -Wno-unsafe-buffer-usage CLANG_W_UNSAFE_BUFFER_USAGE
-    )
-    if (${CLANG_W_UNSAFE_BUFFER_USAGE})
-      list (APPEND clang_options -Wno-unsafe-buffer-usage)
-    endif ()
-  endif ()
-
-  if (URI_WERROR)
-    list (APPEND clang_options -Werror)
-    list (APPEND gcc_options -Werror)
-    list (APPEND msvc_options /WX)
-  endif ()
-
-  if (COVERAGE)
-    list (APPEND gcc_options -fprofile-arcs -ftest-coverage)
-    list (APPEND clang_options -fprofile-instr-generate -fcoverage-mapping)
-  endif ()
-
-  set_target_properties (
-    ${target}
-    PROPERTIES CXX_STANDARD ${STANDARD}
-               CXX_STANDARD_REQUIRED Yes
-               CXX_EXTENSIONS No
-  )
-
-  set (is_clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>)
-  target_compile_options (
-    ${target}
-    PRIVATE
-      $<${is_clang}>:${clang_options}>
-      $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
-      $<$<CXX_COMPILER_ID:MSVC>:${msvc_options}>
-  )
-  target_link_options (
-    ${target}
-    PRIVATE
-      $<${is_clang}>:${clang_options}>
-      $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
-      $<$<CXX_COMPILER_ID:MSVC>:>
-  )
-  if (URI_FUZZTEST)
-    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=1)
-  else()
-    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=0)
-  endif ()
-
-endfunction (setup_target)
-
-# Configure the Google Test targets for our build.
-function (setup_gtest)
-  if (EXISTS "${URI_ROOT}/googletest/CMakeLists.txt")
-    # Tell gtest to link against the "Multi-threaded Debug DLL runtime library"
-    # on Windows.
-    set (gtest_force_shared_crt On CACHE BOOL "Always use msvcrt.dll")
-    # We don't want to install either gtest or gmock.
-    set (INSTALL_GTEST Off CACHE BOOL "Disable gtest install")
-    set (INSTALL_GMOCK Off CACHE BOOL "Disable gmock install")
-    add_subdirectory ("${URI_ROOT}/googletest")
-
-    set (gclangopts )
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-      check_cxx_compiler_flag (
-        -Wno-implicit-int-float-conversion
-        CLANG_W_NO_IMPLICIT_INT_FLOAT_CONVERSION
-      )
-      if (${CLANG_W_NO_IMPLICIT_INT_FLOAT_CONVERSION})
-        list (APPEND gclangopts -Wno-implicit-int-float-conversion)
-      endif ()
-    endif ()
-
-    set (is_clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>)
-
-    # Adjust compiler options for the gtest/gmock.
-    foreach (target gtest gmock gmock_main gtest_main)
-      set_target_properties (
-        ${target}
-        PROPERTIES CXX_STANDARD ${STANDARD}
-                   CXX_STANDARD_REQUIRED Yes
-                   CXX_EXTENSIONS No
-      )
-      target_compile_definitions (
-        ${target} PUBLIC GTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
-      )
-      target_compile_options (${target} PRIVATE $<${is_clang}>:${gclangopts}>)
-      target_link_options (${target} PRIVATE $<${is_clang}>:${gclangopts}>)
-    endforeach ()
-  endif ()
-
-endfunction (setup_gtest)
+include (setup_target)
+include (setup_gtest)
 
 set (URI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
-add_subdirectory (lib)
 
 if (URI_FUZZTEST)
-  include(FetchContent)
-  set(FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")
-  message("Building fuzztest at branch " ${FUZZTEST_REPO_BRANCH})
-  FetchContent_Declare(
+  include (FetchContent)
+  set (FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")
+  message ("Building fuzztest at branch " ${FUZZTEST_REPO_BRANCH})
+  FetchContent_Declare (
     fuzztest
     GIT_REPOSITORY https://github.com/google/fuzztest.git
     GIT_TAG ${FUZZTEST_REPO_BRANCH}
   )
-  FetchContent_MakeAvailable(fuzztest)
-  enable_testing()
-  include(GoogleTest)
-  fuzztest_setup_fuzzing_flags()
+  FetchContent_MakeAvailable (fuzztest)
+  enable_testing ()
+  include (GoogleTest)
+  fuzztest_setup_fuzzing_flags ()
 else ()
   setup_gtest ()
 endif (URI_FUZZTEST)
 
+add_subdirectory (lib)
 if (TARGET gtest)
   add_subdirectory (unittests)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include (setup_gtest)
 
 set (URI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set (FUZZTEST_FUZZING_MODE  ${URI_FUZZTEST_MODE})
 if (URI_FUZZTEST)
   include (FetchContent)
   set (FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")

--- a/cmake/setup_gtest.cmake
+++ b/cmake/setup_gtest.cmake
@@ -1,3 +1,15 @@
+#===- cmake/setup_gtest.cmake ---------------------------------------------===//
+#*           _                       _            _    *
+#*  ___  ___| |_ _   _ _ __     __ _| |_ ___  ___| |_  *
+#* / __|/ _ \ __| | | | '_ \   / _` | __/ _ \/ __| __| *
+#* \__ \  __/ |_| |_| | |_) | | (_| | ||  __/\__ \ |_  *
+#* |___/\___|\__|\__,_| .__/   \__, |\__\___||___/\__| *
+#*                    |_|      |___/                   *
+#===----------------------------------------------------------------------===//
+# Distributed under the MIT License.
+# See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+# SPDX-License-Identifier: MIT
+#===----------------------------------------------------------------------===//
 include (CheckCXXCompilerFlag)
 
 # Configure the Google Test targets for our build.

--- a/cmake/setup_gtest.cmake
+++ b/cmake/setup_gtest.cmake
@@ -1,0 +1,43 @@
+include (CheckCXXCompilerFlag)
+
+# Configure the Google Test targets for our build.
+function (setup_gtest)
+  if (EXISTS "${URI_ROOT}/googletest/CMakeLists.txt")
+    # Tell gtest to link against the "Multi-threaded Debug DLL runtime library"
+    # on Windows.
+    set (gtest_force_shared_crt On CACHE BOOL "Always use msvcrt.dll")
+    # We don't want to install either gtest or gmock.
+    set (INSTALL_GTEST Off CACHE BOOL "Disable gtest install")
+    set (INSTALL_GMOCK Off CACHE BOOL "Disable gmock install")
+    add_subdirectory ("${URI_ROOT}/googletest")
+
+    set (gclangopts )
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+      check_cxx_compiler_flag (
+        -Wno-implicit-int-float-conversion
+        CLANG_W_NO_IMPLICIT_INT_FLOAT_CONVERSION
+      )
+      if (${CLANG_W_NO_IMPLICIT_INT_FLOAT_CONVERSION})
+        list (APPEND gclangopts -Wno-implicit-int-float-conversion)
+      endif ()
+    endif ()
+
+    set (is_clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>)
+
+    # Adjust compiler options for the gtest/gmock.
+    foreach (target gtest gmock gmock_main gtest_main)
+      set_target_properties (
+        ${target}
+        PROPERTIES CXX_STANDARD ${STANDARD}
+                   CXX_STANDARD_REQUIRED Yes
+                   CXX_EXTENSIONS No
+      )
+      target_compile_definitions (
+        ${target} PUBLIC GTEST_REMOVE_LEGACY_TEST_CASEAPI_=1
+      )
+      target_compile_options (${target} PRIVATE $<${is_clang}>:${gclangopts}>)
+      target_link_options (${target} PRIVATE $<${is_clang}>:${gclangopts}>)
+    endforeach ()
+  endif ()
+
+endfunction (setup_gtest)

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -1,0 +1,93 @@
+include (CheckCXXCompilerFlag)
+
+# Configure the named target with a standard set of options which enable lots
+# of warnings, select the desired language standard, and so on.
+function (setup_target target)
+  set (
+    clang_options
+    -Weverything
+    -Wno-c++14-extensions
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-c99-extensions
+    -Wno-exit-time-destructors
+    -Wno-padded
+    -Wno-undef
+    -Wno-weak-vtables
+  )
+  set (gcc_options -Wall -Wextra -pedantic -Wno-maybe-uninitialized)
+  set (
+    msvc_options
+    -W4 # enable lots of warnings
+    -wd4068 # unknown pragma
+    -wd4324 # structure was padded due to alignment specifier
+  )
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    check_cxx_compiler_flag (
+      -Wno-return-std-move-in-c++11 CLANG_RETURN_STD_MOVE_IN_CXX11
+    )
+    if (${CLANG_RETURN_STD_MOVE_IN_CXX11})
+      list (APPEND clang_options -Wno-return-std-move-in-c++11)
+    endif ()
+    check_cxx_compiler_flag (-Wno-c++20-compat CLANG_W_NO_CXX20_COMPAT)
+    if (${CLANG_W_NO_CXX20_COMPAT})
+      list (APPEND clang_options -Wno-c++20-compat)
+    endif ()
+    check_cxx_compiler_flag (-Wno-c++2a-compat CLANG_W_NO_CXX2A_COMPAT)
+    if (${CLANG_W_NO_CXX2A_COMPAT})
+      list (APPEND clang_options -Wno-c++2a-compat)
+    endif ()
+    check_cxx_compiler_flag (
+      -Wno-unsafe-buffer-usage CLANG_W_UNSAFE_BUFFER_USAGE
+    )
+    if (${CLANG_W_UNSAFE_BUFFER_USAGE})
+      list (APPEND clang_options -Wno-unsafe-buffer-usage)
+    endif ()
+  endif ()
+
+  if (URI_WERROR)
+    list (APPEND clang_options -Werror)
+    list (APPEND gcc_options -Werror)
+    list (APPEND msvc_options /WX)
+  endif ()
+
+  if (COVERAGE)
+    list (APPEND gcc_options -fprofile-arcs -ftest-coverage)
+    list (APPEND clang_options -fprofile-instr-generate -fcoverage-mapping)
+  endif ()
+
+  set_target_properties (
+    ${target}
+    PROPERTIES CXX_STANDARD ${STANDARD}
+               CXX_STANDARD_REQUIRED Yes
+               CXX_EXTENSIONS No
+  )
+
+  set (is_clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>)
+  target_compile_options (
+    ${target}
+    PRIVATE
+      $<${is_clang}>:${clang_options}>
+      $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
+      $<$<CXX_COMPILER_ID:MSVC>:${msvc_options}>
+  )
+  target_link_options (
+    ${target}
+    PRIVATE
+      $<${is_clang}>:${clang_options}>
+      $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
+      $<$<CXX_COMPILER_ID:MSVC>:>
+  )
+  if (URI_FUZZTEST)
+    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=1)
+    message ("URI_FUZZTEST_MODE=${URI_FUZZTEST_MODE}")
+    if (URI_FUZZTEST_MODE)
+        message ("setting FUZZTEST_FUZZING_MODE")
+      target_compile_definitions (${target} PUBLIC FUZZTEST_FUZZING_MODE=${URI_FUZZTEST_MODE})
+    endif ()
+  else()
+    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=0)
+  endif ()
+
+endfunction (setup_target)

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -91,6 +91,6 @@ function (setup_target target)
       $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
       $<$<CXX_COMPILER_ID:MSVC>:>
   )
-  target_compile_definitions (${target} PUBLIC URI_FUZZTEST=$<BOOL:$URI_FUZZTEST>)
+  target_compile_definitions (${target} PUBLIC URI_FUZZTEST=$<BOOL:${URI_FUZZTEST}>)
 
 endfunction (setup_target)

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -1,3 +1,15 @@
+#===- cmake/setup_target.cmake --------------------------------------------===//
+#*           _                 _                       _    *
+#*  ___  ___| |_ _   _ _ __   | |_ __ _ _ __ __ _  ___| |_  *
+#* / __|/ _ \ __| | | | '_ \  | __/ _` | '__/ _` |/ _ \ __| *
+#* \__ \  __/ |_| |_| | |_) | | || (_| | | | (_| |  __/ |_  *
+#* |___/\___|\__|\__,_| .__/   \__\__,_|_|  \__, |\___|\__| *
+#*                    |_|                   |___/           *
+#===----------------------------------------------------------------------===//
+# Distributed under the MIT License.
+# See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+# SPDX-License-Identifier: MIT
+#===----------------------------------------------------------------------===//
 include (CheckCXXCompilerFlag)
 
 # Configure the named target with a standard set of options which enable lots

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -91,15 +91,6 @@ function (setup_target target)
       $<$<CXX_COMPILER_ID:GNU>:${gcc_options}>
       $<$<CXX_COMPILER_ID:MSVC>:>
   )
-  if (URI_FUZZTEST)
-    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=1)
-    message ("URI_FUZZTEST_MODE=${URI_FUZZTEST_MODE}")
-    if (URI_FUZZTEST_MODE)
-        message ("setting FUZZTEST_FUZZING_MODE")
-      target_compile_definitions (${target} PUBLIC FUZZTEST_FUZZING_MODE=${URI_FUZZTEST_MODE})
-    endif ()
-  else()
-    target_compile_definitions (${target} PUBLIC URI_FUZZTEST=0)
-  endif ()
+  target_compile_definitions (${target} PUBLIC URI_FUZZTEST=$<BOOL:$URI_FUZZTEST>)
 
 endfunction (setup_target)

--- a/include/uri/pctdecode.hpp
+++ b/include/uri/pctdecode.hpp
@@ -112,14 +112,13 @@ template <std::ranges::input_range View>
   requires std::ranges::forward_range<View>
 class pctdecode_view
     : public std::ranges::view_interface<pctdecode_view<View>> {
+public:
   class iterator;
   class sentinel;
 
-public:
   pctdecode_view ()
     requires std::default_initializable<View>
   = default;
-
   constexpr explicit pctdecode_view (View base) : base_{std::move (base)} {}
 
   template <typename Vp = View>
@@ -130,9 +129,10 @@ public:
   }
   constexpr View base () && { return std::move (base_); }
 
-  constexpr iterator begin () { return {*this, std::ranges::begin (base_)}; }
-
-  constexpr auto end () {
+  constexpr auto begin () const {
+    return iterator{*this, std::ranges::begin (base_)};
+  }
+  constexpr auto end () const {
     if constexpr (std::ranges::common_range<View>) {
       return iterator{*this, std::ranges::end (base_)};
     } else {
@@ -160,7 +160,7 @@ public:
     requires std::default_initializable<std::ranges::iterator_t<View>>
   = default;
 
-  constexpr iterator (pctdecode_view& parent,
+  constexpr iterator (pctdecode_view const& parent,
                       std::ranges::iterator_t<View> current)
       : parent_{std::addressof (parent)}, pos_{std::move (current)} {}
 
@@ -213,7 +213,7 @@ public:
   }
 
 private:
-  [[no_unique_address]] pctdecode_view* parent_ = nullptr;
+  [[no_unique_address]] pctdecode_view const* parent_ = nullptr;
   [[no_unique_address]] std::ranges::iterator_t<View> pos_ =
     std::ranges::iterator_t<View> ();
   mutable std::ranges::range_value_t<View> hex_ = 0;

--- a/unittests/uri/CMakeLists.txt
+++ b/unittests/uri/CMakeLists.txt
@@ -33,7 +33,8 @@ target_compile_options (
 )
 
 if (URI_FUZZTEST)
-  link_fuzztest(unittest)
+  target_link_libraries (unittest PUBLIC gtest gmock)
+  link_fuzztest (unittest)
   gtest_discover_tests (unittest)
 else ()
   target_link_libraries (unittest PUBLIC gmock_main)


### PR DESCRIPTION
- Split up CMakeLists.txt.
- Fix a compile-time failure with C++20 ranges.
- Improve the fuzz build scripts.
- Update action to enable fuzz testing mode.