### PR TITLE
Merge the URI code point enum and the pct-encode equivalent.

### DIFF
--- a/include/uri/rule.hpp
+++ b/include/uri/rule.hpp
@@ -79,16 +79,14 @@
 #ifndef URI_RULE_HPP
 #define URI_RULE_HPP
 
-#include <algorithm>
-#include <array>
-#include <cassert>
 #include <cctype>
 #include <functional>
-#include <iterator>
 #include <limits>
 #include <optional>
 #include <string_view>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace uri {
@@ -232,12 +230,13 @@ rule rule::star (MatchFunction const match, unsigned const min,
     }
     ++count;
     if (count > max) {
-      break;
+      break;  // Stop after max repeats.
     }
+    // Strip the matched text from the string.
     auto const l = std::get<std::string_view> (*m).length ();
     str.remove_prefix (l);
     length += l;
-
+    // Remember the corresponding acceptor functions.
     auto const& a = std::get<acceptor_container> (*m);
     acc.insert (acc.end (), a.begin (), a.end ());
   }
@@ -263,6 +262,8 @@ rule rule::alternative (MatchFunction match, Rest&&... rest) const {
   return this->alternative (std::forward<Rest> (rest)...);
 }
 
+// is nop
+// ~~~~~~
 template <typename Function>
 constexpr bool rule::is_nop (Function f) const noexcept {
   if constexpr (std::is_pointer_v<Function>) {
@@ -349,37 +350,6 @@ inline auto digit (rule const& r) {
 inline auto hexdig (rule const& r) {
   return r.single_char (
     [] (char const c) { return std::isxdigit (static_cast<int> (c)); });
-}
-
-inline auto commercial_at (rule const& r) {
-  return r.single_char ('@');
-}
-inline auto colon (rule const& r) {
-  return r.single_char (':');
-}
-inline auto hash (rule const& r) {
-  return r.single_char ('#');
-}
-inline auto plus (rule const& r) {
-  return r.single_char ('+');
-}
-inline auto minus (rule const& r) {
-  return r.single_char ('-');
-}
-inline auto solidus (rule const& r) {
-  return r.single_char ('/');
-}
-inline auto question_mark (rule const& r) {
-  return r.single_char ('?');
-}
-inline auto full_stop (rule const& r) {
-  return r.single_char ('.');
-}
-inline auto left_square_bracket (rule const& r) {
-  return r.single_char ('[');
-}
-inline auto right_square_bracket (rule const& r) {
-  return r.single_char (']');
 }
 
 }  // end namespace uri

--- a/include/uri/uri.hpp
+++ b/include/uri/uri.hpp
@@ -14,29 +14,44 @@
 #define URI_URI_HPP
 
 #include <filesystem>
+#include <iosfwd>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
-#include "uri/pctdecode.hpp"
-#include "uri/pctencode.hpp"
-
 namespace uri {
 
-enum class code_points : char32_t {
+enum class code_point : unsigned {
   null = 0x00,
   tab = 0x09,
   lf = 0x0A,
   cr = 0x0D,
   space = 0x20,
-  number_sign = 0x23,
-  solidus = 0x2F,
   exclamation_mark = 0x21,
+  number_sign = 0x23,
+  dollar_sign = 0x24,
+  percent_sign = 0x25,
+  ampersand = 0x26,
+  apostrophe = 0x27,
+  left_parenthesis = 0x28,
+  right_parenthesis = 0x29,
+  asterisk = 0x2A,
+  plus_sign = 0x2B,
+  comma = 0x2C,
+  hyphen_minus = 0x2D,
+  full_stop = 0x2E,
+  solidus = 0x2F,
   digit_zero = 0x30,
+  digit_one = 0x31,
+  digit_two = 0x32,
+  digit_four = 0x34,
+  digit_five = 0x35,
   digit_nine = 0x39,
   colon = 0x3A,
+  semi_colon = 0x3B,
   less_than_sign = 0x3C,
+  equals_sign = 0x3D,
   greater_than_sign = 0x3E,
   question_mark = 0x3F,
   commercial_at = 0x40,
@@ -46,7 +61,9 @@ enum class code_points : char32_t {
   reverse_solidus = 0x5C,
   right_square_bracket = 0x5D,
   circumflex_accent = 0x5E,
+  low_line = 0x5F,
   latin_small_letter_a = 0x61,
+  latin_small_letter_v = 0x76,
   latin_small_letter_z = 0x7A,
   vertical_line = 0x7C,
   tilde = 0x7E,

--- a/lib/uri/pctencode.cpp
+++ b/lib/uri/pctencode.cpp
@@ -12,46 +12,40 @@
 //===----------------------------------------------------------------------===//
 #include "uri/pctencode.hpp"
 
+#include "uri/uri.hpp"
+
 namespace {
 
-enum class code_point : unsigned {
-  space = 0x20,
-  exclamation_mark = 0x21,
-  digit_zero = 0x30,
-  digit_nine = 0x39,
-  latin_capital_letter_a = 0x41,
-  latin_capital_letter_z = 0x5A,
-  latin_small_letter_a = 0x61,
-  latin_small_letter_z = 0x7A,
-  tilde = 0x7E,
-};
-
-constexpr bool operator<= (unsigned const x, code_point const y) noexcept {
-  return x <= static_cast<std::underlying_type_t<code_point>> (y);
+constexpr bool operator<= (unsigned const x, uri::code_point const y) noexcept {
+  return x <= static_cast<std::underlying_type_t<uri::code_point>> (y);
 }
-constexpr bool operator> (unsigned const x, code_point const y) noexcept {
-  return x > static_cast<std::underlying_type_t<code_point>> (y);
+constexpr bool operator> (unsigned const x, uri::code_point const y) noexcept {
+  return x > static_cast<std::underlying_type_t<uri::code_point>> (y);
 }
-constexpr bool operator>= (unsigned const x, code_point const y) noexcept {
-  return x >= static_cast<std::underlying_type_t<code_point>> (y);
+constexpr bool operator>= (unsigned const x, uri::code_point const y) noexcept {
+  return x >= static_cast<std::underlying_type_t<uri::code_point>> (y);
 }
 
-constexpr code_point operator+ (code_point const x, unsigned const y) noexcept {
-  return static_cast<code_point> (
-    static_cast<std::underlying_type_t<code_point>> (x) + y);
+constexpr uri::code_point operator+ (uri::code_point const x,
+                                     unsigned const y) noexcept {
+  return static_cast<uri::code_point> (
+    static_cast<std::underlying_type_t<uri::code_point>> (x) + y);
 }
-constexpr code_point operator- (code_point const x,
-                                code_point const y) noexcept {
-  using ut = std::underlying_type_t<code_point>;
+constexpr uri::code_point operator- (uri::code_point const x,
+                                     uri::code_point const y) noexcept {
+  using ut = std::underlying_type_t<uri::code_point>;
   assert (static_cast<ut> (x) >= static_cast<ut> (y));
-  return static_cast<code_point> (static_cast<ut> (x) - static_cast<ut> (y));
+  return static_cast<uri::code_point> (static_cast<ut> (x) -
+                                       static_cast<ut> (y));
 }
-constexpr code_point operator- (unsigned const x, code_point const y) noexcept {
-  using ut = std::underlying_type_t<code_point>;
+constexpr uri::code_point operator- (unsigned const x,
+                                     uri::code_point const y) noexcept {
+  using ut = std::underlying_type_t<uri::code_point>;
   assert (x >= static_cast<ut> (y));
-  return static_cast<code_point> (x - static_cast<ut> (y));
+  return static_cast<uri::code_point> (x - static_cast<ut> (y));
 }
-std::uint_least8_t& operator-= (std::uint_least8_t& x, code_point const y) {
+std::uint_least8_t& operator-= (std::uint_least8_t& x,
+                                uri::code_point const y) {
   x = static_cast<std::uint_least8_t> (x - y);
   return x;
 }

--- a/lib/uri/rule.cpp
+++ b/lib/uri/rule.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 #include "uri/rule.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <iostream>

--- a/lib/uri/rule.cpp
+++ b/lib/uri/rule.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 
 namespace uri {
 

--- a/lib/uri/rule.cpp
+++ b/lib/uri/rule.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 #include "uri/rule.hpp"
 
+#include <cassert>
 #include <iomanip>
 #include <iostream>
 

--- a/lib/uri/uri.cpp
+++ b/lib/uri/uri.cpp
@@ -21,18 +21,19 @@ using namespace uri;
 namespace {
 
 inline auto single_code_point (rule const& r, code_point const cp) {
-  using ut = std::underlying_type_t<code_point>;
-  assert (static_cast<ut> (cp) <=
-          static_cast<ut> (std::numeric_limits<char>::max ()));
+  assert (static_cast<std::underlying_type_t<code_point>> (cp) <=
+          static_cast<std::underlying_type_t<code_point>> (
+            std::numeric_limits<char>::max ()));
   return r.single_char (static_cast<char> (cp));
 }
 
 inline auto code_point_range (code_point const first, code_point const last) {
-  using ut = std::underlying_type_t<code_point>;
-  assert (static_cast<ut> (first) <=
-          static_cast<ut> (std::numeric_limits<char>::max ()));
-  assert (static_cast<ut> (last) <=
-          static_cast<ut> (std::numeric_limits<char>::max ()));
+  assert (static_cast<std::underlying_type_t<code_point>> (first) <=
+          static_cast<std::underlying_type_t<code_point>> (
+            std::numeric_limits<char>::max ()));
+  assert (static_cast<std::underlying_type_t<code_point>> (last) <=
+          static_cast<std::underlying_type_t<code_point>> (
+            std::numeric_limits<char>::max ()));
   return [f = std::tolower (static_cast<int> (first)),
           l = std::tolower (static_cast<int> (last))] (rule const& r) {
     return r.single_char ([=] (char const c) {

--- a/lib/uri/uri.cpp
+++ b/lib/uri/uri.cpp
@@ -106,23 +106,23 @@ auto single_colon (rule const& r) {
 //               / "*" / "+" / "," / ";" / "="
 auto sub_delims (rule const& r) {
   return r.single_char ([] (char const c) {
-    using enum code_point;
     auto const cp = static_cast<code_point> (c);
-    return cp == exclamation_mark || cp == dollar_sign || cp == ampersand ||
-           cp == apostrophe || cp == left_parenthesis ||
-           cp == right_parenthesis || cp == asterisk || cp == plus_sign ||
-           cp == comma || cp == semi_colon || cp == equals_sign;
+    return cp == code_point::exclamation_mark ||
+           cp == code_point::dollar_sign || cp == code_point::ampersand ||
+           cp == code_point::apostrophe || cp == code_point::left_parenthesis ||
+           cp == code_point::right_parenthesis || cp == code_point::asterisk ||
+           cp == code_point::plus_sign || cp == code_point::comma ||
+           cp == code_point::semi_colon || cp == code_point::equals_sign;
   });
 }
 
 // unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
 auto unreserved (rule const& r) {
   return r.single_char ([] (char const c) {
-    using enum code_point;
     auto const cp = static_cast<code_point> (c);
     return static_cast<bool> (std::isalnum (static_cast<int> (c))) ||
-           cp == hyphen_minus || cp == full_stop || cp == low_line ||
-           cp == tilde;
+           cp == code_point::hyphen_minus || cp == code_point::full_stop ||
+           cp == code_point::low_line || cp == code_point::tilde;
   });
 }
 

--- a/unittests/uri/test_uri.cpp
+++ b/unittests/uri/test_uri.cpp
@@ -26,6 +26,8 @@
 #include "fuzztest/fuzztest.h"
 #endif
 
+#include "uri/pctencode.hpp"
+
 // to address
 // ~~~~~~~~~~
 #if defined(__cpp_lib_to_address)


### PR DESCRIPTION
Start using code-point values rather than character constants. Fix up the some of the includes list.