### PR TITLE
Hide excessive warnings from the fuzztest framework.

### DIFF
--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Fuzz
         run: |
-          "$BUILD_DIR/unittests/uri/unittest" --fuzz_for 10s
+          "$BUILD_DIR/unittests/uri/unittest" --fuzz_for 30s

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -15,8 +15,20 @@ include (CheckCXXCompilerFlag)
 # Configure the named target with a standard set of options which enable lots
 # of warnings, select the desired language standard, and so on.
 function (setup_target target)
+  cmake_parse_arguments (
+    arg # prefix
+    "" # options
+    "PEDANTIC" # one-value-keywords
+    "" # multi-value-keywords
+    ${ARGN}
+  )
+  # PEDANTIC defaults to "Yes".
+  if ("${arg_PEDANTIC}" STREQUAL "")
+    set (arg_PEDANTIC "Yes")
+  endif ()
+
   set (
-    clang_options
+    clang_warning_options
     -Weverything
     -Wno-c++14-extensions
     -Wno-c++98-compat
@@ -27,9 +39,14 @@ function (setup_target target)
     -Wno-undef
     -Wno-weak-vtables
   )
-  set (gcc_options -Wall -Wextra -pedantic -Wno-maybe-uninitialized)
+  set (gcc_warning_options
+    -Wall
+    -Wextra
+    -pedantic
+    -Wno-maybe-uninitialized
+  )
   set (
-    msvc_options
+    msvc_warning_options
     -W4 # enable lots of warnings
     -wd4068 # unknown pragma
     -wd4324 # structure was padded due to alignment specifier
@@ -38,13 +55,13 @@ function (setup_target target)
   set (is_clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>)
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     check_cxx_compiler_flag (-Wno-return-std-move-in-c++11 CLANG_W_NO_RETURN_STD_MOVE_IN_CXX11)
-    list (APPEND clang_options $<$<BOOL:${CLANG_W_NO_RETURN_STD_MOVE_IN_CXX11}>:-Wno-return-std-move-in-c++11>)
+    list (APPEND clang_warning_options $<$<BOOL:${CLANG_W_NO_RETURN_STD_MOVE_IN_CXX11}>:-Wno-return-std-move-in-c++11>)
     check_cxx_compiler_flag (-Wno-c++20-compat CLANG_W_NO_CXX20_COMPAT)
-    list (APPEND clang_options $<$<BOOL:${CLANG_W_NO_CXX20_COMPAT}>:-Wno-c++20-compat>)
+    list (APPEND clang_warning_options $<$<BOOL:${CLANG_W_NO_CXX20_COMPAT}>:-Wno-c++20-compat>)
     check_cxx_compiler_flag (-Wno-c++2a-compat CLANG_W_NO_CXX2A_COMPAT)
-    list (APPEND clang_options $<$<BOOL:${CLANG_W_NO_CXX2A_COMPAT}>:-Wno-c++2a-compat>)
+    list (APPEND clang_warning_options $<$<BOOL:${CLANG_W_NO_CXX2A_COMPAT}>:-Wno-c++2a-compat>)
     check_cxx_compiler_flag (-Wno-unsafe-buffer-usage CLANG_W_UNSAFE_BUFFER_USAGE)
-    list (APPEND clang_options $<$<BOOL:${CLANG_W_UNSAFE_BUFFER_USAGE}>:-Wno-unsafe-buffer-usage>)
+    list (APPEND clang_warning_options $<$<BOOL:${CLANG_W_UNSAFE_BUFFER_USAGE}>:-Wno-unsafe-buffer-usage>)
   endif ()
 
   if (URI_WERROR)
@@ -57,6 +74,10 @@ function (setup_target target)
     list (APPEND gcc_options -fprofile-arcs -ftest-coverage)
     list (APPEND clang_options -fprofile-instr-generate -fcoverage-mapping)
   endif ()
+
+  list (APPEND clang_options $<$<BOOL:${arg_PEDANTIC}>:${clang_warning_options}>)
+  list (APPEND gcc_options   $<$<BOOL:${arg_PEDANTIC}>:${gcc_warning_options}>)
+  list (APPEND msvc_options  $<$<BOOL:${arg_PEDANTIC}>:${msvc_warning_options}>)
 
   target_compile_features (${target} PUBLIC $<IF:$<BOOL:${URI_CXX17}>,cxx_std_17,cxx_std_20>)
   target_compile_options (

--- a/unittests/uri/CMakeLists.txt
+++ b/unittests/uri/CMakeLists.txt
@@ -17,9 +17,6 @@ add_executable (unittest
   test_rule.cpp
   test_uri.cpp
 )
-target_link_libraries (unittest PUBLIC uri)
-
-setup_target (unittest)
 target_compile_options (
   unittest
   PRIVATE
@@ -31,6 +28,8 @@ target_compile_options (
     $<$<CXX_COMPILER_ID:MSVC>:
       -wd4702>
 )
+target_link_libraries (unittest PUBLIC uri)
+setup_target (unittest PEDANTIC $<NOT:$<BOOL:${URI_FUZZTEST}>>)
 add_test(NAME unittest COMMAND unittest)
 
 if (URI_FUZZTEST)


### PR DESCRIPTION
Add a PEDENTIC switch to setup target so that we add maximum warnings to uri code but not to the fuzztesting framework.

Extend fuzzing time to 30 seconds.