### PR TITLE
Add 'parts' which add functions to encode and decode URL components.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
         if: matrix.xcode_version != ''
         run: |
           ls /Applications/Xcode*.app
-          sudo xcode-select -s /Applications/Xcode.${{matrix.xcode_version}}.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_${{matrix.xcode_version}}.app/Contents/Developer
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,17 +11,17 @@ jobs:
         include:
           # macOS builds
           # ~~~~~~~~~~~~
-          - name: macOS-13/Xcode/Debug
+          - name: macOS-14/Xcode/Debug
             build_type: Debug
             generator: Xcode
             options:
-            os: macos-13
+            os: macos-14
 
-          - name: macOS-13/Xcode/Release
+          - name: macOS-14/Xcode/Release
             build_type: Release
             generator: Xcode
             options:
-            os: macos-13
+            os: macos-14
 
           # Linux builds
           # ~~~~~~~~~~~~

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,14 +25,6 @@ jobs:
 
           # Linux builds
           # ~~~~~~~~~~~~
-          - name: Ubuntu-20.04/clang-15/Debug/C++17
-            apt_install: clang-15 cmake libc++-15-dev libc++abi-15-dev ninja-build
-            build_type: Debug
-            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
-            generator: Ninja
-            options: -D URI_CXX17=Yes -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
-            os: ubuntu-22.04
-
           - name: Ubuntu-22.04/gcc-11/Debug
             apt_install: cmake ninja-build
             build_type: Debug
@@ -63,14 +55,6 @@ jobs:
             options: -D URI_CXX17=No -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 
-          - name: Ubuntu-22.04/clang-15/Release/C++17
-            apt_install: clang-15 cmake libc++-15-dev libc++abi-15-dev ninja-build
-            build_type: Release
-            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
-            generator: Ninja
-            options: -D URI_CXX17=Yes -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
-            os: ubuntu-22.04
-
           # Windows builds
           # ~~~~~~~~~~~~~~
           - name: Windows-latest/VS2022/Debug
@@ -83,12 +67,6 @@ jobs:
             build_type: Release
             generator: Visual Studio 17 2022
             options: -D URI_CXX17=No
-            os: windows-latest
-
-          - name: Windows-latest/VS2022/Debug/C++17
-            build_type: Debug
-            generator: Visual Studio 17 2022
-            options: -D URI_CXX17=Yes
             os: windows-latest
 
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,29 +14,31 @@ jobs:
           - name: macOS-13/Xcode/Debug
             build_type: Debug
             generator: Xcode
-            options: -D URI_CXX17=No
+            options:
             os: macos-13
 
           - name: macOS-13/Xcode/Release
             build_type: Release
             generator: Xcode
-            options: -D URI_CXX17=No
+            options:
             os: macos-13
 
           # Linux builds
           # ~~~~~~~~~~~~
-          - name: Ubuntu-22.04/gcc-11/Debug
+          - name: Ubuntu-22.04/gcc-12/Debug
             apt_install: cmake ninja-build
             build_type: Debug
+	    cxx_compiler; -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
             generator: Ninja
-            options: -D URI_CXX17=No
+            options:
             os: ubuntu-22.04
 
-          - name: Ubuntu-22.04/gcc-11/Release
+          - name: Ubuntu-22.04/gcc-12/Release
             apt_install: cmake ninja-build
             build_type: Release
+  	    cxx_compiler; -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
             generator: Ninja
-            options: -D URI_CXX17=No
+            options:
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-15/Debug
@@ -44,7 +46,7 @@ jobs:
             build_type: Debug
             cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
             generator: Ninja
-            options: -D URI_CXX17=No -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 
           - name: Ubuntu-22.04/clang-15/Release
@@ -52,7 +54,7 @@ jobs:
             build_type: Release
             cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
             generator: Ninja
-            options: -D URI_CXX17=No -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 
           # Windows builds
@@ -60,13 +62,13 @@ jobs:
           - name: Windows-latest/VS2022/Debug
             build_type: Debug
             generator: Visual Studio 17 2022
-            options: -D URI_CXX17=No
+            options:
             os: windows-latest
 
           - name: Windows-latest/VS2022/Release
             build_type: Release
             generator: Visual Studio 17 2022
-            options: -D URI_CXX17=No
+            options:
             os: windows-latest
 
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           - name: Ubuntu-22.04/gcc-12/Debug
             apt_install: cmake ninja-build
             build_type: Debug
-	    cxx_compiler; -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
+            cxx_compiler: -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
             generator: Ninja
             options:
             os: ubuntu-22.04
@@ -36,7 +36,7 @@ jobs:
           - name: Ubuntu-22.04/gcc-12/Release
             apt_install: cmake ninja-build
             build_type: Release
-  	    cxx_compiler; -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
+            cxx_compiler: -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
             generator: Ninja
             options:
             os: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,5 +127,6 @@ jobs:
 
       - name: Build
         shell: bash
-        run: cmake --build "${{ github.workspace }}/build" \
-                   --config ${{ matrix.build_type }}
+        run: |
+          cmake --build "${{ github.workspace }}/build" \
+                --config ${{ matrix.build_type }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
             generator: Xcode
             options:
             os: macos-14
+            xcode_version: 15.3
 
           - name: macOS-14/Xcode/Release
             build_type: Release
@@ -103,6 +104,12 @@ jobs:
           sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{matrix.llvm_install}}
+
+      - name: Select Xcode (macOS)
+        if: matrix.xcode_version != ''
+        run: |
+          ls /Applications/Xcode*.app
+          sudo xcode-select -s /Applications/Xcode.${{matrix.xcode_version}}.app/Contents/Developer
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
             generator: Xcode
             options:
             os: macos-14
+            xcode_version: 15.3
 
           # Linux builds
           # ~~~~~~~~~~~~
@@ -108,7 +109,6 @@ jobs:
       - name: Select Xcode (macOS)
         if: matrix.xcode_version != ''
         run: |
-          ls /Applications/Xcode*.app
           sudo xcode-select -s /Applications/Xcode_${{matrix.xcode_version}}.app/Contents/Developer
 
       - name: Create Build Environment
@@ -127,4 +127,5 @@ jobs:
 
       - name: Build
         shell: bash
-        run: cmake --build "${{ github.workspace }}/build" --config ${{ matrix.build_type }}
+        run: cmake --build "${{ github.workspace }}/build" \
+                   --config ${{ matrix.build_type }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,36 +25,38 @@ jobs:
 
           # Linux builds
           # ~~~~~~~~~~~~
-          - name: Ubuntu-22.04/gcc-12/Debug
-            apt_install: cmake ninja-build
+          - name: Ubuntu-22.04/gcc-13/Debug
+            apt_install: cmake ninja-build g++-13 libstdc++-10-dev
             build_type: Debug
-            cxx_compiler: -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
+            cxx_compiler: -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13
             generator: Ninja
             options:
             os: ubuntu-22.04
 
-          - name: Ubuntu-22.04/gcc-12/Release
-            apt_install: cmake ninja-build
+          - name: Ubuntu-22.04/gcc-13/Release
+            apt_install: cmake ninja-build g++-13 libstdc++-10-dev
             build_type: Release
-            cxx_compiler: -D CMAKE_C_COMPILER=gcc-12 -D CMAKE_CXX_COMPILER=g++-12
+            cxx_compiler: -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13
             generator: Ninja
             options:
             os: ubuntu-22.04
 
-          - name: Ubuntu-22.04/clang-15/Debug
-            apt_install: clang-15 cmake libc++-15-dev libc++abi-15-dev ninja-build
+          - name: Ubuntu-22.04/clang-16/Debug
+            apt_install: cmake ninja-build
+            llvm_install: 16
             build_type: Debug
-            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
+            cxx_compiler: -D CMAKE_C_COMPILER=clang-16 -D CMAKE_CXX_COMPILER=clang++-16
             generator: Ninja
-            options: -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 
-          - name: Ubuntu-22.04/clang-15/Release
-            apt_install: clang-15 cmake libc++-15-dev libc++abi-15-dev ninja-build
+          - name: Ubuntu-22.04/clang-16/Release
+            apt_install: cmake ninja-build
+            llvm_install: 16
             build_type: Release
-            cxx_compiler: -D CMAKE_CXX_COMPILER=clang++-15 -D CMAKE_C_COMPILER=clang-15
+            cxx_compiler: -D CMAKE_C_COMPILER=clang-16 -D CMAKE_CXX_COMPILER=clang++-16
             generator: Ninja
-            options: -D URI_LIBCXX=Yes -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+            options: -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
             os: ubuntu-22.04
 
           # Windows builds
@@ -87,7 +89,20 @@ jobs:
 
       - name: Install Dependencies (Linux)
         if: startsWith (matrix.os, 'ubuntu-') && matrix.apt_install != ''
-        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.apt_install }}
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+          sudo apt-get update && \
+          sudo apt-get install -y ${{ matrix.apt_install }}
+
+      - name: Install Dependencies (LLVM)
+        if: matrix.llvm_install != ''
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          # Force --yes to the end of the add-apt-repository command to
+          # prevent the llvm.sh script hanging.
+          sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{matrix.llvm_install}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{ github.workspace }}/build

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -26,11 +26,16 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y            \
-            "clang-${CLANG_VERSION}"         \
-            cmake                            \
-            "libc++-${CLANG_VERSION}-dev"    \
-            "libc++abi-${CLANG_VERSION}-dev"
+          sudo apt-get install -y cmake
+
+      - name: Install Dependencies (LLVM)
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          # Force --yes to the end of the add-apt-repository command to
+          # prevent the llvm.sh script hanging.
+          sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${CLANG_VERSION}
 
       - name: Configure
         run: |

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -9,7 +9,8 @@ permissions:
 jobs:
   fuzztest:
     name: Fuzz Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+
     env:
       BUILD_DIR: build_fuzztest
       CLANG_VERSION: 16
@@ -35,19 +36,19 @@ jobs:
           # prevent the llvm.sh script hanging.
           sed -ie "/^add-apt-repository/ s/$/ --yes/" llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${CLANG_VERSION}
+          sudo ./llvm.sh "${CLANG_VERSION}"
 
       - name: Configure
         run: |
           mkdir "$BUILD_DIR"
           cmake                                            \
-            -S .                                           \
+            -S "$GITHUB_WORKSPACE"                         \
             -B "$BUILD_DIR"                                \
+            -G "Unix Makefiles"                            \
             -D CMAKE_BUILD_TYPE=RelWithDebug               \
-            -D CMAKE_CXX_COMPILER="clang++-$CLANG_VERSION" \
-            -D CMAKE_C_COMPILER="clang-$CLANG_VERSION"     \
-            -D URI_FUZZTEST=Yes                            \
-            -D URI_LIBCXX=Yes
+            -D "CMAKE_CXX_COMPILER=clang++-$CLANG_VERSION" \
+            -D "CMAKE_C_COMPILER=clang-$CLANG_VERSION"     \
+            -D URI_FUZZTEST=Yes
 
       - name: Build
         run: |

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_DIR: build_fuzztest
-      CLANG_VERSION: 15
+      CLANG_VERSION: 16
 
     steps:
       - name: Harden Runner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@
 #===----------------------------------------------------------------------===//
 cmake_minimum_required (VERSION 3.19)
 project (uri CXX)
+
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option (URI_CXX17 "Use C++17 (rather than C++20)" No)
 option (URI_FUZZTEST "Enable FuzzTest")
 option (URI_LIBCXX "Use libc++ rather than libstdc++")
 option (URI_WERROR "Compiler warnings are errors")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,20 +31,20 @@ set (URI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 if (URI_FUZZTEST)
   set (FUZZTEST_FUZZING_MODE On)
   include (FetchContent)
-  set (FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")
-  message ("Building fuzztest at branch " ${FUZZTEST_REPO_BRANCH})
+  set (FUZZTEST_REPO_BRANCH "1635d42" CACHE STRING "FuzzTest repository branch.")
+  message ("Building fuzztest at tag " ${FUZZTEST_REPO_BRANCH})
   FetchContent_Declare (
     fuzztest
     GIT_REPOSITORY https://github.com/google/fuzztest.git
     GIT_TAG ${FUZZTEST_REPO_BRANCH}
   )
   FetchContent_MakeAvailable (fuzztest)
-  enable_testing ()
   include (GoogleTest)
   fuzztest_setup_fuzzing_flags ()
 else ()
   setup_gtest ()
 endif (URI_FUZZTEST)
+enable_testing ()
 
 add_subdirectory (lib)
 if (TARGET gtest)

--- a/cmake/setup_target.cmake
+++ b/cmake/setup_target.cmake
@@ -34,6 +34,7 @@ function (setup_target target)
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
     -Wno-c99-extensions
+    -Wno-covered-switch-default
     -Wno-exit-time-destructors
     -Wno-padded
     -Wno-undef
@@ -95,5 +96,4 @@ function (setup_target target)
       $<$<CXX_COMPILER_ID:MSVC>:>
   )
   target_compile_definitions (${target} PUBLIC URI_FUZZTEST=$<BOOL:${URI_FUZZTEST}>)
-
 endfunction (setup_target)

--- a/include/uri/icubaby.hpp
+++ b/include/uri/icubaby.hpp
@@ -1,0 +1,2286 @@
+//*  _         _          _          *
+//* (_)__ _  _| |__  __ _| |__ _  _  *
+//* | / _| || | '_ \/ _` | '_ \ || | *
+//* |_\__|\_,_|_.__/\__,_|_.__/\_, | *
+//*                            |__/  *
+// Home page:
+// https://paulhuggett-icubaby.rtfd.io
+//
+// MIT License
+//
+// Copyright (c) 2022-2024 Paul Bowen-Huggett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/// \file   icubaby.hpp
+///
+/// \brief  A C++ Baby Library to Immediately Convert Unicode. A header only, dependency free,
+///         library for C++ 17 or later. Fast, minimal, and easy to use for converting a sequence
+///         in any of UTF-8, UTF-16, or UTF-32.
+///
+/// \mainpage
+/// A C++ Library to Immediately Convert Unicode. It is a portable, header-only, dependency-free library for C++ 17 or
+/// later. Fast, minimal, and easy to use for converting sequences of text between any of the Unicode UTF encodings. It
+/// does not allocate dynamic memory and neither throws or catches exceptions.
+///
+/// \example view_utf32_to_16.cpp
+/// An example showing conversion of an array UTF-32 encoded code points can be converted to UTF-16 using the C++ 20
+/// ranges interface.
+///
+/// \example iterator.cpp
+/// The icubaby::iterator<> class offers a familiar output iterator for using a transcoder. Each code unit from the
+/// input encoding is written to the iterator and this in turn writes the output encoding to a second iterator. This
+/// enables use of standard algorithms such as std::copy() with the library.
+///
+/// \example bytes_to_utf8.cpp
+/// This code converts an array of bytes containing the string "Hello World" in UTF-16 BE with an initial byte order
+/// mark first to UTF-8 and then to an array of std::uint_least8_t. We finally copy these values to std::cout.
+///
+/// \example manual_bytes_to_utf8.cpp
+/// This code shows how icubaby makes it straightforward to convert a byte array to a sequence of Unicode code units
+/// passing one byte at a time to a transcoder instance. We take the bytes making up the string "Hello World" expressed
+/// in big endian UTF-16 (with a byte order marker) and convert them to UTF-8 which is written directly to `std::cout`.
+
+// UTF-8 to UTF-32 conversion is based on the "Flexible and Economical UTF-8
+// Decoder" by Bjoern Hoehrmann <bjoern@hoehrmann.de> See
+// http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+//
+// Copyright (c) 2008-2010 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ICUBABY_ICUBABY_HPP
+#define ICUBABY_ICUBABY_HPP
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <variant>
+
+/// \brief ICUBABY_CXX20 has value 1 when compiling with C++ 20 or later and 0
+///   otherwise.
+/// \hideinitializer
+#if __cplusplus >= 202002L
+#define ICUBABY_CXX20 (1)
+#elif defined(_MSVC_LANG) && _MSVC_LANG >= 202002L
+// MSVC does not set the value of __cplusplus correctly unless the
+// /Zc:__cplusplus is supplied. We have to detect C++20 using its
+// compiler-specific macros instead.
+#define ICUBABY_CXX20 (1)
+#else
+#define ICUBABY_CXX20 (0)
+#endif
+
+#ifndef ICUBABY_CXX20
+#include <version>
+#endif
+
+/// \brief Defined as 1 if the standard library's __cpp_lib_ranges macro is available and 0 otherwise.
+/// \hideinitializer
+#ifdef __cpp_lib_ranges
+#define ICUBABY_CPP_LIB_RANGES_DEFINED (1)
+#else
+#define ICUBABY_CPP_LIB_RANGES_DEFINED (0)
+#endif
+
+/// \brief Tests for the availability of library support for C++ 20 ranges.
+/// \hideinitializer
+#define ICUBABY_HAVE_RANGES (ICUBABY_CPP_LIB_RANGES_DEFINED && __cpp_lib_ranges >= 201811L)
+#if ICUBABY_HAVE_RANGES
+#include <ranges>
+#endif
+
+/// \brief Defined as true if compiler and library support for concepts are available.
+/// \hideinitializer
+#ifdef __cpp_concepts
+#define ICUBABY_CPP_CONCEPTS_DEFINED (1)
+#else
+#define ICUBABY_CPP_CONCEPTS_DEFINED (0)
+#endif
+
+/// \brief Defined as 1 if the standard library's __cpp_lib_concepts macro is available and 0 otherwise.
+/// \hideinitializer
+#ifdef __cpp_lib_concepts
+#define ICUBABY_CPP_LIB_CONCEPTS_DEFINED (1)
+#else
+#define ICUBABY_CPP_LIB_CONCEPTS_DEFINED (0)
+#endif
+
+/// \brief A macro that evaluates true if the compiler and library have support for C++ 20 concepts.
+/// \hideinitializer
+#define ICUBABY_HAVE_CONCEPTS                                                                       \
+  (ICUBABY_CPP_CONCEPTS_DEFINED && __cpp_concepts >= 201907L && ICUBABY_CPP_LIB_CONCEPTS_DEFINED && \
+   __cpp_lib_concepts >= 202002L)
+
+#if ICUBABY_HAVE_CONCEPTS
+#include <concepts>
+/// \brief Defined as `requires x` if C++ 20 concepts are supported and as nothing otherwise.
+/// \hideinitializer
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ICUBABY_REQUIRES(x) requires x
+/// \brief Defined as `std::output_iterator<x>` if C++ 20 concepts are supported and as `typename` otherwise.
+/// \hideinitializer
+///
+/// Used as a shortcut to restrict a specific template argument to be an output iterator in C++ 20 and simply
+/// declaring a typename in C++ 17.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ICUBABY_CONCEPT_OUTPUT_ITERATOR(x) std::output_iterator<x>
+/// \brief A convenience macro for defining a template argument that must be icubaby::unicode_char_type.
+/// \hideinitializer
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define ICUBABY_CONCEPT_UNICODE_CHAR_TYPE unicode_char_type
+#else
+#define ICUBABY_REQUIRES(x)
+#define ICUBABY_CONCEPT_OUTPUT_ITERATOR(x) typename
+#define ICUBABY_CONCEPT_UNICODE_CHAR_TYPE typename
+#endif  // ICUBABY_HAVE_CONCEPTS
+
+/// \brief Defined as `[[no_unique_address]]` if the attribute is supported and
+///   as nothing otherwise.
+/// \hideinitializer
+#if ICUBABY_CXX20
+#define ICUBABY_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define ICUBABY_NO_UNIQUE_ADDRESS
+#endif
+
+#ifdef ICUBABY_INSIDE_NS
+namespace ICUBABY_INSIDE_NS {
+#endif
+
+/// \brief The namespace for the icubaby library.
+namespace icubaby {
+
+/// \brief Private implementation details of the icubaby interface.
+///
+/// Functions and types defined in this namespace are not part of the icubaby public interface
+/// and should not be used in client code. They may change at any time!
+namespace details {
+
+/// \brief A compile-time list of types.
+///
+/// An instance of type_list represents an element in a list. It is somewhat
+/// like a cons cell in Lisp: it has two slots, and each slot holds a type.
+/// A list is formed when a series of type_list instances are chained together,
+/// so that each cell refers to the next one. There is one type_list instance
+/// for each list member. The 'first' member holds a member type and the 'rest'
+/// field is used to chain together type_list instances. The end of the list is
+/// represented by a type_list specialization which takes no arguments and
+/// contains no members.
+template <typename... Types> struct type_list;
+
+/// \brief A compile-time list of types. This specialization defines the end of the list.
+/// \see type_list, type_list<First, Rest>.
+template <> struct type_list<> {};
+
+/// \brief A compile-time list of types. This specialization holds a member of the list.
+/// \see type_list, type_list<>.
+template <typename First, typename Rest> struct type_list<First, Rest> {
+  using first = First;  ///< The first member of a list of types.
+  using rest = Rest;    ///< The remaining members of the type list.
+};
+
+#if ICUBABY_HAVE_CONCEPTS
+/// \brief Defines the requirements of a type that is a member of a type list.
+///
+/// An element in a type list must contain member types names 'first' and
+/// 'rest'. The end of the list is given by the type_list<> specialization.
+template <typename T>
+concept is_type_list = requires {
+  typename T::first;
+  typename T::rest;
+} || std::is_same_v<T, type_list<>>;
+#endif
+
+/// \brief Constructs a type_list from a template parameter pack.
+/// \see make<>, make<T, Ts...>, make_t
+template <typename... Types> struct make;
+/// \brief Constructs an empty type_list.
+/// \see make, make<T, Ts...>, make_t
+template <> struct make<> {
+  using type = type_list<>;  ///< An empty type list.
+};
+/// \brief Constructs a type_list from a template parameter pack.
+/// \see make, make<>, make_t
+template <typename T, typename... Ts> struct make<T, Ts...> {
+  /// A list of types.
+  ///
+  /// The first element of the list is type \p T: the remaining members
+  /// are \p Ts.
+  using type = type_list<T, typename make<Ts...>::type>;
+};
+/// \brief A helper template for make<>.
+template <typename... Types> using make_t = typename make<Types...>::type;
+
+/// \brief Yields true if the type list contains a type matching \p Element
+///   and false otherwise.
+/// \see contains_v
+/// \tparam TypeList A list of types (formed by type_list).
+/// \tparam Element  The type to be checked.
+template <typename TypeList, typename Element>
+ICUBABY_REQUIRES (is_type_list<TypeList>)
+struct contains : std::bool_constant<std::is_same_v<Element, typename TypeList::first> ||
+                                     contains<typename TypeList::rest, Element>::value> {};
+/// \brief Yields false: the empty type list does not contain a type matching \p Element.
+/// \see contains_v
+/// \tparam Element  The type to be checked.
+template <typename Element> struct contains<type_list<>, Element> : std::bool_constant<false> {};
+
+/// A helper variable template for contains<>.
+template <typename TypeList, typename Element> inline constexpr bool contains_v = contains<TypeList, Element>::value;
+
+}  // end namespace details
+
+/// \brief The type of a UTF-8 code unit.
+/// Defined as `char8_t` when the native type is available and `char` otherwise.
+/// \hideinitializer
+#if defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+using char8 = char8_t;
+#else
+using char8 = char;
+#endif
+
+/// A UTF-8 string.
+using u8string = std::basic_string<char8>;
+/// A UTF-8 string_view.
+using u8string_view = std::basic_string_view<char8>;
+
+/// A constant for the U+FFFD REPLACEMENT CHARACTER code point
+inline constexpr auto replacement_char = char32_t{0xFFFD};
+/// A constant for the U+FEFF ZERO WIDTH NO-BREAK SPACE (BYTE ORDER MARK) code point
+inline constexpr auto zero_width_no_break_space = char32_t{0xFEFF};
+/// A constant for the U+FEFF ZERO WIDTH NO-BREAK SPACE (BYTE ORDER MARK) code point
+inline constexpr auto byte_order_mark = zero_width_no_break_space;
+
+/// \brief The number of bits required to represent a code point.
+///
+/// Starting with Unicode 2.0, characters are encoded in the range
+/// U+0000..U+10FFFF, which amounts to a 21-bit code space.
+inline constexpr auto code_point_bits = 21U;
+
+/// The code point of the first UTF-16 high surrogate.
+inline constexpr auto first_high_surrogate = char32_t{0xD800};
+/// The code point of the last UTF-16 high surrogate.
+inline constexpr auto last_high_surrogate = char32_t{0xDBFF};
+/// The code point of the first UTF-16 low surrogate.
+inline constexpr auto first_low_surrogate = char32_t{0xDC00};
+/// The code point of the last UTF-16 low surrogate.
+inline constexpr auto last_low_surrogate = char32_t{0xDFFF};
+
+/// The number of the last code point.
+inline constexpr auto max_code_point = char32_t{0x10FFFF};
+static_assert (uint_least32_t{1} << code_point_bits > max_code_point);
+
+/// A list of the character types used for UTF-8 UTF-16, and UTF-32 encoded
+/// text.
+using character_types = details::make_t<char8, char16_t, char32_t>;
+
+/// \brief Checks whether the argument is one of the unicode character types
+///
+/// Provides the boolean constant `value` which is true if T is one of the unicode character types as defined by
+/// icubaby::character_types and false otherwise.
+///
+/// \tparam T  The type to be checked.
+template <typename T> struct is_unicode_char_type : std::bool_constant<details::contains_v<character_types, T>> {};
+/// \brief A helper variable template to simplify use of icubaby::is_unicode_char_type.
+template <typename T> inline constexpr bool is_unicode_char_type_v = is_unicode_char_type<T>::value;
+
+/// \brief Checks whether the argument is one of the unicode data source types
+///
+/// Provides the constant `value` which is equal to true if T is one of the types which may contain unicode data
+/// otherwise, value is equal to false. The unicode data types are the types allowed by
+/// icubaby::is_unicode_char_type_v plus ``std::byte``.
+///
+/// \tparam T  The type to be checked.
+template <typename T>
+struct is_unicode_input_type : std::bool_constant<is_unicode_char_type_v<T> || std::is_same_v<T, std::byte>> {};
+
+/// \brief A helper variable template to simplify use of icubaby::is_unicode_input_type.
+template <typename T> inline constexpr bool is_unicode_input_v = is_unicode_input_type<T>::value;
+
+#if ICUBABY_HAVE_CONCEPTS
+
+/// \brief Checks whether the argument is one of the unicode character types
+///
+/// The unicode_char_type concept defines the requires of a type that matches one of the types that denote a
+/// Unicode encoding.
+template <typename T>
+concept unicode_char_type = is_unicode_char_type_v<T>;
+
+/// \brief Checks whether the argument is one of the unicode data source types
+///
+/// The unicode_char_type concept defines the requires of a type that matches one of the types that denote a
+/// Unicode data source.
+template <typename T>
+concept unicode_input = is_unicode_input_v<T>;
+
+#endif  // ICUBABY_HAVE_CONCEPTS
+
+/// \brief The number of code-units in the longest legal representation of a code-point.
+///
+/// Provides the constant `value` which is of type `std::size_t`.
+///
+/// \tparam Encoding The encoding to be used.
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE Encoding> struct longest_sequence {};
+/// \brief The number of code-units in the longest legal UTF-8 representation of a code-point.
+template <> struct longest_sequence<char8> : std::integral_constant<std::size_t, 4> {};
+/// \brief The number of code-units in the longest legal UTF-16 representation of a code-point.
+template <> struct longest_sequence<char16_t> : std::integral_constant<std::size_t, 2> {};
+/// \brief The number of code-units in the longest legal UTF-32 representation of a code-point.
+template <> struct longest_sequence<char32_t> : std::integral_constant<std::size_t, 1> {};
+/// \brief A helper variable template to simplify use of icubaby::longest_sequence<>.
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE Encoding>
+inline constexpr auto longest_sequence_v = longest_sequence<Encoding>::value;
+
+/// \brief Returns true if the code point \p code_point represents a UTF-16 high surrogate.
+///
+/// \param code_point  The code point to be tested.
+/// \returns true if the code point \p code_point represents a UTF-16 high surrogate.
+constexpr bool is_high_surrogate (char32_t code_point) noexcept {
+  return code_point >= first_high_surrogate && code_point <= last_high_surrogate;
+}
+/// \brief Returns true if the code point \p code_point represents a UTF-16 low surrogate.
+///
+/// \param code_point  The code point to be tested.
+/// \returns true if the code point \p code_point represents a UTF-16 low surrogate.
+constexpr bool is_low_surrogate (char32_t code_point) noexcept {
+  return code_point >= first_low_surrogate && code_point <= last_low_surrogate;
+}
+/// \brief Returns true if the code point \p code_point represents a UTF-16 low or high surrogate.
+///
+/// \param code_point  The code point to be tested.
+/// \returns true if the code point \p c represents a UTF-16 high or low surrogate.
+constexpr bool is_surrogate (char32_t code_point) noexcept {
+  return is_high_surrogate (code_point) || is_low_surrogate (code_point);
+}
+
+/// \name Code Point Start
+///@{
+
+/// \brief Returns true if \p code_unit represents the start of a multi-byte UTF-8 sequence.
+///
+/// \param code_unit  The UTF-8 code unit to be tested.
+/// \returns true if \p code_unit represents the start of a multi-byte UTF-8 sequence.
+constexpr bool is_code_point_start (char8 code_unit) noexcept {
+  static_assert (sizeof (code_unit) == sizeof (std::byte));
+  return (static_cast<std::byte> (code_unit) & std::byte{0xC0}) != std::byte{0x80};
+}
+/// \brief Returns true if \p code_unit represents the start of a UTF-16 high/low surrogate pair.
+///
+/// \param code_unit  The UTF-16 code unit to be tested.
+/// \returns  true if \p code_unit represents the start of a UTF-16 high/low surrogate pair.
+constexpr bool is_code_point_start (char16_t code_unit) noexcept {
+  return !is_low_surrogate (code_unit);
+}
+/// \brief Returns true if \p code_unit represents a valid UTF-32 code point.
+///
+/// \param code_unit  The UTF-32 code unit to be tested.
+/// \returns  true if \p code_unit represents a valid UTF-32 code point.
+constexpr bool is_code_point_start (char32_t code_unit) noexcept {
+  return !is_surrogate (code_unit) && code_unit <= max_code_point;
+}
+///@}
+
+#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+/// \brief Returns the number of code points in a sequence.
+///
+/// \note The input sequence must be well formed for the result to be accurate.
+/// \tparam Range  An input range.
+/// \tparam Proj  Type of the projection applied to elements.
+/// \param range The range of the elements to examine.
+/// \param proj  Projection to apply to the elements.
+/// \returns  The number of code points.
+template <std::ranges::input_range Range, typename Proj = std::identity>
+  requires unicode_char_type<std::ranges::range_value_t<Range>>
+constexpr std::ranges::range_difference_t<Range> length (Range&& range, Proj proj = {}) {
+  return std::ranges::count_if (
+      std::forward<Range> (range),
+      [] (unicode_char_type auto const code_unit) { return is_code_point_start (code_unit); }, proj);
+}
+
+/// \brief Returns the number of code points in a sequence.
+///
+/// \note The input sequence must be well formed for the result to be accurate.
+/// \param first  The start of the range of code units to examine.
+/// \param last  The end of the range of code units to examine.
+/// \param proj  Projection to apply to the elements.
+/// \returns  The number of code points.
+template <std::input_iterator I, std::sentinel_for<I> S, typename Proj = std::identity>
+  requires unicode_char_type<typename std::iterator_traits<I>::value_type>
+constexpr std::iter_difference_t<I> length (I first, S last, Proj proj = {}) {
+  return length (std::ranges::subrange{first, last}, proj);
+}
+
+#else
+
+/// \brief Returns the number of code points in a sequence.
+///
+/// \note The input sequence must be well formed for the result to be accurate.
+/// \param first  The start of the range of code units to examine.
+/// \param last  The end of the range of code units to examine.
+/// \returns  The number of code points.
+template <typename InputIterator,
+          typename = std::enable_if_t<is_unicode_char_type_v<typename std::iterator_traits<InputIterator>::value_type>>>
+constexpr typename std::iterator_traits<InputIterator>::difference_type length (InputIterator first,
+                                                                                InputIterator last) {
+  return std::count_if (first, last, [] (auto c) { return is_code_point_start (c); });
+}
+
+#endif  // ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+/// Returns an iterator to the beginning of the pos'th code point in the range of code-units given by \p range.
+///
+/// \tparam Range  An input range.
+/// \tparam Proj   The type of the projection applied to elements.
+/// \param range  The range of code units to examine.
+/// \param pos  The number of code points to move.
+/// \param proj  Projection to apply to the elements.
+/// \returns  Iterator to the start of the selected code point or iterator equal to last if no such element is found.
+template <std::ranges::input_range Range, typename Proj = std::identity>
+constexpr std::ranges::borrowed_iterator_t<Range> index (Range&& range, std::size_t pos, Proj proj = {}) {
+  auto count = std::size_t{0};
+  return std::ranges::find_if (
+      std::forward<Range> (range),
+      [&count, pos] (unicode_char_type auto const code_unit) {
+        return is_code_point_start (code_unit) ? (count++ == pos) : false;
+      },
+      proj);
+}
+
+/// Returns an iterator to the beginning of the pos'th code point in the code
+/// unit sequence [first, last).
+///
+/// \param first  The start of the range of code units to examine.
+/// \param last  The end of the range of code units to examine.
+/// \param pos  The number of code points to move.
+/// \param proj  Projection to apply to the elements.
+/// \returns  An iterator that is 'pos' code points after the start of the range or
+///           'last' if the end of the range was encountered.
+template <std::input_iterator I, std::sentinel_for<I> S, typename Proj = std::identity>
+constexpr I index (I first, S last, std::size_t pos, Proj proj = {}) {
+  return index (std::ranges::subrange{first, last}, pos, proj);
+}
+
+#else
+
+/// Returns an iterator to the beginning of the pos'th code point in the code
+/// unit sequence [first, last).
+///
+/// \param first  The start of the range of code units to examine.
+/// \param last  The end of the range of code units to examine.
+/// \param pos  The number of code points to move.
+/// \returns  An iterator that is 'pos' code points after the start of the range or
+///           'last' if the end of the range was encountered.
+template <typename InputIterator,
+          typename = std::enable_if_t<is_unicode_char_type_v<typename std::iterator_traits<InputIterator>::value_type>>>
+constexpr InputIterator index (InputIterator first, InputIterator last, std::size_t pos) {
+  auto count = std::size_t{0};
+  return std::find_if (first, last, [&count, pos] (auto c) {
+    static_assert (is_unicode_char_type_v<std::decay_t<decltype (c)>>);
+    return is_code_point_start (c) ? (count++ == pos) : false;
+  });
+}
+
+#endif  // ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+#if ICUBABY_HAVE_CONCEPTS
+/// \brief Defines the requirements of a type that provides the transcoder interface.
+template <typename T>
+concept is_transcoder = requires (T tcdr) {
+  typename T::input_type;
+  typename T::output_type;
+  // we must also have operator() and end_cp() which
+  // both take template arguments.
+  { tcdr.well_formed () } -> std::convertible_to<bool>;
+  { tcdr.partial () } -> std::convertible_to<bool>;
+};
+
+#endif  // ICUBABY_HAVE_CONCEPTS
+
+template <typename Transcoder, typename OutputIterator>
+ICUBABY_REQUIRES ((is_transcoder<Transcoder> && std::output_iterator<OutputIterator, typename Transcoder::output_type>))
+class iterator;
+
+/// \brief A transcoder takes a sequence of either bytes or Unicode code-units (one of UTF-8, 16 or 32) and
+///   converts it to another Unicode encoding.
+///
+/// Each of the specializations of this template (there is one for each input/output combination) supplies the same
+/// interface.
+#if ICUBABY_HAVE_CONCEPTS
+template <unicode_input FromEncoding, unicode_char_type ToEncoding>
+#else
+template <typename FromEncoding, typename ToEncoding>
+#endif  // ICUBABY_HAVE_CONCEPTS
+class transcoder {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = FromEncoding;
+  /// The type of the code units produced by this transcoder.
+  using output_type = ToEncoding;
+
+  /// \anchor transcoder-call-operator
+  /// This member function is the heart of the transcoder. It accepts a single byte
+  /// or code unit in the input encoding and, once an entire code point has been consumed, produces
+  /// the equivalent code point expressed in the output encoding. Malformed input is detected and
+  /// replaced with the Unicode replacement character (U+FFFD REPLACEMENT CHARACTER).
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type transcoder::output_type can be written.
+  /// \param code_unit  A code unit in the source encoding.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) noexcept;
+
+  /// Call once the entire input sequence has been fed to \ref transcoder-call-operator "operator()". This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type transcoder::output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr OutputIterator end_cp (OutputIterator dest) const;
+
+  /// Call once the entire input sequence has been fed to \ref transcoder-call-operator "operator()". This
+  /// function ensures that the sequence did not end with a partial code point and flushes any
+  /// remaining output.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type transcoder::output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest);
+
+  /// Indicates whether the input was well formed
+  /// \returns True if the input was well formed.
+  [[nodiscard]] constexpr bool well_formed () const noexcept;
+
+  /// \brief Indicates whether a "partial" code point has been passed to \ref transcoder-call-operator "operator()".
+  ///
+  /// If true, one or more code units are required to build the complete code point.
+  ///
+  /// \returns True if a partial code-point has been passed to \ref transcoder-call-operator "operator()" and
+  ///   false otherwise.
+  [[nodiscard]] constexpr bool partial () const noexcept;
+};
+
+/// \brief An output iterator which passes code units being output through a
+///   transcoder.
+///
+/// This iterator simplifies the job of converting unicode representation and
+/// storing the results of that conversion. Each time that a code point is
+/// recovered from the sequence written to this class, the equivalent
+/// sequence is written to the iterator with which the object was constructed.
+///
+/// For example, a function to convert a UTF-16 string to UTF-8 becomes very
+/// simple:
+/// ~~~
+/// std::u8string utf16_to_8_demo (std::u16string u16) {
+///   std::u8string u8;
+///   icubaby::t16_8 t;
+///   icubaby::iterator out{&t, std::back_inserter(u8)};
+///   t.end_cp (std::copy (u16.begin(), u16.end(), out));
+///   return u8;
+/// }
+/// ~~~
+///
+/// \tparam Transcoder  A transcoder type.
+/// \tparam OutputIterator  An output iterator type.
+template <typename Transcoder, typename OutputIterator>
+ICUBABY_REQUIRES ((is_transcoder<Transcoder> && std::output_iterator<OutputIterator, typename Transcoder::output_type>))
+class iterator {
+public:
+  /// Defines this class as fulfilling the requirements of an output iterator.
+  using iterator_category = std::output_iterator_tag;
+  /// The class is an output iterator and as such does not yield values.
+  using value_type = void;
+  /// A type that can be used to identify distance between iterators.
+  using difference_type = std::ptrdiff_t;
+  /// Defines a pointer to the type iterated over (none in the case of this iterator).
+  using pointer = void;
+  /// Defines a reference to the type iterated over (none in the case of this iterator).
+  using reference = void;
+
+  /// Initializes the underlying transcoder and the output iterator to which elements will be written.
+  ///
+  /// \param transcoder  The underlying transcoder. This class does not take ownership of the pointer.
+  /// \param out  An output iterator to which code units produced by the \p transcoder will be written.
+  iterator (Transcoder* transcoder, OutputIterator out) : transcoder_{transcoder}, out_{out} {}
+  iterator (iterator const& rhs) = default;
+  iterator (iterator&& rhs) noexcept = default;
+
+  ~iterator () noexcept = default;
+
+  /// Passes a code unit to the associated transcoder.
+  /// \param value The code unit to be passed to the transcoder.
+  /// \returns \*this
+  iterator& operator= (typename Transcoder::input_type const& value) {
+    out_ = (*transcoder_) (value, out_);
+    return *this;
+  }
+
+  iterator& operator= (iterator const& rhs) = default;
+  iterator& operator= (iterator&& rhs) noexcept = default;
+
+  /// \brief no-op
+  /// \returns \*this
+  constexpr iterator& operator* () noexcept { return *this; }
+  /// \brief no-op
+  /// \returns \*this
+  constexpr iterator& operator++ () noexcept { return *this; }
+  /// \brief no-op
+  /// \returns \*this
+  constexpr iterator operator++ (int) noexcept { return *this; }
+
+  /// Accesses the underlying iterator.
+  [[nodiscard]] constexpr OutputIterator base () const noexcept { return out_; }
+  /// Accesses the underlying transcoder.
+  [[nodiscard]] constexpr Transcoder* transcoder () noexcept { return transcoder_; }
+  /// Accesses the underlying transcoder.
+  [[nodiscard]] constexpr Transcoder const* transcoder () const noexcept { return transcoder_; }
+
+private:
+  /// The transcoder that will be used to convert code units when they are assigned.
+  Transcoder* transcoder_;
+  /// An output iterator to which code units produced by the transcoder will be written.
+  ICUBABY_NO_UNIQUE_ADDRESS OutputIterator out_;
+};
+
+/// A class template argument deduction guide for icubaby::iterator.
+template <typename Transcoder, typename OutputIterator>
+iterator (Transcoder& transcoder, OutputIterator out) -> iterator<Transcoder, OutputIterator>;
+
+/// Takes a sequence of UTF-32 code units and converts them to UTF-8.
+template <> class transcoder<char32_t, char8> {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = char32_t;
+  /// The type of the code units produced by this transcoder.
+  using output_type = char8;
+
+  constexpr transcoder () noexcept = default;
+  /// Initializes a transcoder instance with an initial value for its "well formed" state. This can be useful if
+  /// converting a stream of data which may be using different encodings.
+  ///
+  /// \param well_formed The initial value for the transcoder's "well formed" state.
+  explicit constexpr transcoder (bool well_formed) noexcept : well_formed_{well_formed} {}
+
+  /// Accepts a code unit in the UTF-32 source encoding. As UTF-8 output code units are generated, they are written to
+  /// the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param code_unit  A code unit in the source encoding.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) noexcept {
+    if (code_unit < 0x80) {
+      *(dest++) = static_cast<output_type> (code_unit);
+      return dest;
+    }
+    if (code_unit < 0x800) {
+      return transcoder::write2 (code_unit, dest);
+    }
+    if (is_surrogate (code_unit)) {
+      return transcoder::not_well_formed (dest);
+    }
+    if (code_unit < 0x10000) {
+      return transcoder::write3 (code_unit, dest);
+    }
+    if (code_unit <= max_code_point) {
+      return transcoder::write4 (code_unit, dest);
+    }
+    return transcoder::not_well_formed (dest);
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr OutputIterator end_cp (OutputIterator dest) const {
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input represented well formed UTF-32.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+
+private:
+  /// True if the input consumed is well formed, false otherwise.
+  bool well_formed_ = true;
+
+  /// Writes a two CU value to the output.
+  ///
+  /// \param code_unit  The code unit to be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <typename OutputIterator> static OutputIterator write2 (input_type code_unit, OutputIterator dest) {
+    *(dest++) = static_cast<output_type> ((code_unit >> 6U) | 0xc0U);
+    *(dest++) = static_cast<output_type> ((code_unit & 0x3fU) | 0x80U);
+    return dest;
+  }
+  /// Writes a three CU value to the output.
+  ///
+  /// \param code_unit  The code unit to be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <typename OutputIterator> static OutputIterator write3 (input_type code_unit, OutputIterator dest) {
+    *(dest++) = static_cast<output_type> ((code_unit >> 12U) | 0xe0U);
+    *(dest++) = static_cast<output_type> (((code_unit >> 6U) & 0x3fU) | 0x80U);
+    *(dest++) = static_cast<output_type> ((code_unit & 0x3fU) | 0x80U);
+    return dest;
+  }
+  /// Writes a four CU value to the output.
+  ///
+  /// \param code_unit  The code unit to be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <typename OutputIterator> static OutputIterator write4 (input_type code_unit, OutputIterator dest) {
+    *(dest++) = static_cast<output_type> ((code_unit >> 18U) | 0xf0U);
+    *(dest++) = static_cast<output_type> (((code_unit >> 12U) & 0x3fU) | 0x80U);
+    *(dest++) = static_cast<output_type> (((code_unit >> 6U) & 0x3fU) | 0x80U);
+    *(dest++) = static_cast<output_type> ((code_unit & 0x3fU) | 0x80U);
+    return dest;
+  }
+  /// Writes U+FFFD REPLACEMENT CHAR to the output and records the input as not well formed.
+  ///
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <typename OutputIterator> OutputIterator not_well_formed (OutputIterator dest) {
+    well_formed_ = false;
+    static_assert (!is_surrogate (replacement_char));
+    return (*this) (replacement_char, dest);
+  }
+};
+
+/// Takes a sequence of UTF-8 code units and converts them to UTF-32.
+template <> class transcoder<char8, char32_t> {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = char8;
+  /// The type of the code units produced by this transcoder.
+  using output_type = char32_t;
+
+  constexpr transcoder () noexcept : transcoder (true) {}
+  /// Initializes a transcoder instance with an initial value for its "well formed" state. This can be useful if
+  /// converting a stream of data which may be using different encodings.
+  ///
+  /// \param well_formed The initial value for the transcoder's "well formed" state.
+  explicit constexpr transcoder (bool well_formed) noexcept
+      : code_point_{0}, well_formed_{static_cast<uint_least32_t> (well_formed)}, pad_{0}, state_{accept} {
+    // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+    pad_ = 0;  // Suppress warning about pad_ being unused.
+  }
+
+  /// Accepts a code unit in the UTF-8 source encoding. As UTF-32 output code units are generated, they are written to
+  /// the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of
+  ///   output_type can be written.
+  /// \param code_unit  A UTF-8 code unit,
+  /// \param dest  Iterator to which the output should be written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) {
+    // Prior to C++20, char8 might be signed.
+    static_assert (sizeof (input_type) == sizeof (std::uint8_t));
+    auto const ucu = static_cast<std::uint8_t> (code_unit);
+    static_assert (std::is_unsigned_v<decltype (ucu)> && std::numeric_limits<decltype (ucu)>::max () <= utf8d_.size ());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    auto const type = utf8d_[ucu];
+    code_point_ = (state_ != accept)
+                      ? static_cast<std::uint_least32_t> (static_cast<std::byte> (code_unit) & std::byte{0x3FU}) |
+                            static_cast<uint_least32_t> (code_point_ << 6U)
+                      : (0xFFU >> type) & ucu;
+    auto const idx = 256U + state_ + type;
+    assert (idx < utf8d_.size ());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    state_ = utf8d_[idx];
+    switch (state_) {
+    case accept: *(dest++) = code_point_; break;
+    case reject:
+      well_formed_ = false;
+      state_ = accept;
+      *(dest++) = replacement_char;
+      break;
+    default: break;
+    }
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr OutputIterator end_cp (OutputIterator dest) {
+    if (state_ != accept) {
+      state_ = reject;
+      *(dest++) = replacement_char;
+      well_formed_ = false;
+    }
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input represented well formed UTF-8.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] constexpr bool partial () const noexcept { return state_ != accept; }
+
+private:
+  /// The utf8d_ table consists of two parts. The first part maps bytes to character classes, the
+  /// second part encodes a deterministic finite automaton using these character classes as
+  /// transitions.
+  /// \hideinitializer
+  static inline std::array<uint8_t, 364> const utf8d_ = {{
+      // clang-format off
+    // The first part of the table maps bytes to character classes that
+    // to reduce the size of the transition table and create bitmasks.
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+     1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,  9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+     7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+     8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+    10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,
+
+    // The second part is a transition table that maps a combination
+    // of a state of the automaton and a character class to a state.
+     0,12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,
+    12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,
+    12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,
+    12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,
+    12,36,12,12,12,12,12,12,12,12,12,12,
+      // clang-format on
+  }};
+  /// The code point value being assembled from input code units.
+  uint_least32_t code_point_ : code_point_bits;
+  /// True if the input consumed is well formed, false otherwise.
+  uint_least32_t well_formed_ : 1;
+  /// Pad bits intended to put the next value to a byte boundary.
+  uint_least32_t pad_ : 2;
+  enum : std::uint8_t { accept, reject = 12 };
+  /// The state of the converter.
+  uint_least32_t state_ : 8;
+};
+
+/// Takes a sequence of UTF-32 code units and converts them to UTF-16.
+template <> class transcoder<char32_t, char16_t> {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = char32_t;
+  /// The type of the code units produced by this transcoder.
+  using output_type = char16_t;
+
+  constexpr transcoder () noexcept = default;
+  /// Initializes a transcoder instance with an initial value for its "well formed" state. This can be useful if
+  /// converting a stream of data which may be using different encodings.
+  ///
+  /// \param well_formed The initial value for the transcoder's "well formed" state.
+  explicit constexpr transcoder (bool well_formed) noexcept : well_formed_{well_formed} {}
+
+  /// Accepts a code unit in the UTF-32 source encoding. As UTF-16 output code units are generated, they are written to
+  /// the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of
+  ///   output_type can be written.
+  /// \param code_unit  A UTF-32 code unit,
+  /// \param dest  Iterator to which the output should be written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) noexcept {
+    if (is_surrogate (code_unit) || code_unit > max_code_point) {
+      dest = (*this) (replacement_char, dest);
+      well_formed_ = false;
+    } else if (code_unit <= 0xFFFF) {
+      *(dest++) = static_cast<output_type> (code_unit);
+    } else {
+      *(dest++) = static_cast<output_type> (0xD7C0U + (code_unit >> 10U));
+      *(dest++) = static_cast<output_type> (first_low_surrogate + (code_unit & 0x3FFU));
+    }
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  The output iterator.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr OutputIterator end_cp (OutputIterator dest) noexcept {
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input represented valid UTF-32.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+
+private:
+  /// True if the input consumed is well formed, false otherwise.
+  bool well_formed_ = true;
+};
+
+/// Takes a sequence of UTF-16 code units and converts them to UTF-32.
+template <> class transcoder<char16_t, char32_t> {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = char16_t;
+  /// The type of the code units produced by this transcoder.
+  using output_type = char32_t;
+
+  constexpr transcoder () noexcept : transcoder (true) {}
+  /// Initializes a transcoder instance with an initial value for its "well formed" state. This can be useful if
+  /// converting a stream of data which may be using different encodings.
+  ///
+  /// \param well_formed The initial value for the transcoder's "well formed" state.
+  explicit constexpr transcoder (bool well_formed) noexcept
+      : high_{0},
+        has_high_{static_cast<uint_least16_t> (false)},
+        well_formed_{static_cast<uint_least16_t> (well_formed)} {}
+
+  /// Accepts a code unit in the UTF-16 source encoding. As UTF-32 output code units are generated, they are written to
+  /// the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param code_unit  A code unit in the source encoding.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) noexcept {
+    if (!has_high_) {
+      if (is_high_surrogate (code_unit)) {
+        // A high surrogate code unit indicates that this is the first of a
+        // high/low surrogate pair.
+        high_ = adjusted_high (code_unit);
+        has_high_ = true;
+        return dest;
+      }
+
+      // A low surrogate without a preceeding high surrogate.
+      if (is_low_surrogate (code_unit)) {
+        well_formed_ = false;
+        code_unit = replacement_char;
+      }
+      *(dest++) = code_unit;
+      return dest;
+    }
+
+    // A high surrogate followed by a low surrogate.
+    if (is_low_surrogate (code_unit)) {
+      *(dest++) = (static_cast<char32_t> (high_) << high_bits) + (code_unit - first_low_surrogate) + 0x10000;
+      high_ = 0;
+      has_high_ = false;
+      return dest;
+    }
+    // There was a high surrogate followed by something other than a low
+    // surrogate. A high surrogate followed by a second high surrogate yields
+    // a single REPLACEMENT CHARACTER. A high followed by something other than
+    // a low surrogate gives REPLACEMENT CHARACTER followed by the second input
+    // code point.
+    *(dest++) = replacement_char;
+    well_formed_ = false;
+    if (is_high_surrogate (code_unit)) {
+      // There was a high surrogate followed by a second high surrogate. Remember the later of the two.
+      high_ = adjusted_high (code_unit);
+      assert (has_high_);
+      return dest;
+    }
+
+    *(dest++) = code_unit;
+    high_ = 0;
+    has_high_ = false;
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  The output iterator.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator> OutputIterator end_cp (OutputIterator dest) {
+    if (has_high_) {
+      *(dest++) = replacement_char;
+      high_ = 0;
+      has_high_ = false;
+      well_formed_ = false;
+    }
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input represented well formed UTF-16.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] constexpr bool partial () const noexcept { return has_high_; }
+
+private:
+  /// The number of bits required to represent a high surrogate value.
+  static constexpr auto high_bits = 10U;
+  /// The previous high surrogate that was passed to operator(). Valid if
+  /// has_high_ is true.
+  uint_least16_t high_ : high_bits;
+  /// true if the previous code unit passed to operator() was a high surrogate,
+  /// false otherwise.
+  uint_least16_t has_high_ : 1;
+  /// true if the code units passed to operator() represent well formed UTF-16
+  /// input, false otherwise.
+  uint_least16_t well_formed_ : 1;
+
+  /// \brief This function returns a high surrogate value that can be stored in the high_ field.
+  ///
+  /// The high surrogate value is stored after the first_high_surrogate value has been subtracted. This reduces the
+  /// number of bits that we need to remember.
+  ///
+  /// \param code_unit A UYTF-16 code unit for which icubaby::is_high_surrogate() returns true.
+  /// \returns A high surrogate value that can be stored in the class's high_ field.
+  static std::uint_least16_t adjusted_high (std::uint_least16_t code_unit) noexcept {
+    assert (code_unit >= first_high_surrogate && "A high surrogate must be at least first_high_surrogate");
+    auto const high_cu = code_unit - first_high_surrogate;
+    assert (high_cu < std::numeric_limits<decltype (high_)>::max () && high_cu < (1U << high_bits) &&
+            "high_cu won't fit in the high_ field!");
+    return static_cast<uint_least16_t> (high_cu);
+  }
+};
+
+/// \brief An enumeration representing the encoding detected by transcoder<std::byte, X>.
+enum class encoding {
+  unknown,  ///< No encoding has yet been determined.
+  utf8,     ///< The detected encoding is UTF-8.
+  utf16be,  ///< The detected encoding is big-endian UTF-16.
+  utf16le,  ///< The detected encoding is little-endian UTF-16.
+  utf32be,  ///< The detected encoding is big-endian UTF-32.
+  utf32le,  ///< The detected encoding is little-endian UTF-32.
+};
+
+namespace details {
+
+/// An alias template for a two-dimensional std::array
+template <typename T, std::size_t Row, std::size_t Col> using array2d = std::array<std::array<T, Col>, Row>;
+
+/// \brief A two-dimensional array containing the bytes that make up the encoded value of U+FEFF BYTE ORDER MARK.
+///
+/// \note The indices of the outer array must agree with the [encoding_utf16](\ref transcoder-encoding_utf16),
+///       [encoding_utf32](\ref transcoder-encoding_utf32), [encoding_utf8](\ref transcoder-encoding_utf8),
+///       [big_endian](\ref transcoder-big_endian), and [little_endian](\ref transcoder-little_endian) constants from
+///       the transcoder<std::byte, ToEncoding> specialization. We use the encoding and endian fields together to
+///       produce the outer index into this array. UTF-8 encoding has no inherant endianness so is modelled as
+///       big-endian to enable it to occupy just the final entry in this array
+inline array2d<std::byte, 5, 4> const boms{{
+    {std::byte{0xFE}, std::byte{0xFF}},                                    // UTF-16 BE
+    {std::byte{0xFF}, std::byte{0xFE}},                                    // UTF-16 LE
+    {std::byte{0x00}, std::byte{0x00}, std::byte{0xFE}, std::byte{0xFF}},  // UTF-32 BE
+    {std::byte{0xFF}, std::byte{0xFE}, std::byte{0x00}, std::byte{0x00}},  // UTF-32 LE
+    {std::byte{0xEF}, std::byte{0xBB}, std::byte{0xBF}},                   // UTF-8
+}};
+
+}  // end namespace details
+
+/// \brief The "byte transcoder" takes a sequence of bytes, determines their encoding and converts
+///    to a specified encoding.
+///
+/// This transcoder is used when the input encoding is not known at compile-time. If present, a leading
+/// byte-order-mark is interpreted to select the source encoding; if not present, UTF-8 encoding is assumed.
+///
+/// The byte transcoder is implemented as a finite state machine. The following diagram shows the state transitions that
+/// occur as input bytes are received. Each vertex rectangle represents a state (the upper half has the state name
+/// and the lower briefly describes the meaning of that state). Each edge describes the condition for that transition to
+/// be made.
+///
+/// - An edge with description of the form *x=y* (where *y* is a hexadecimal constant) is taken if the input value *x*
+///   is equal to the constant *y*.
+/// - An edge with the description "otherwise" is taken if no other edges with the same origin are matched.
+/// - An edge without a description is unconditionally taken for the next byte
+///
+/// \dotfile byte_transcoder.dot
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding> class transcoder<std::byte, ToEncoding> {
+public:
+  /// The type of the values consumed by this transcoder.
+  using input_type = std::byte;
+  /// The type of the code units produced by this transcoder.
+  using output_type = ToEncoding;
+
+  /// \brief Accepts a byte for decoding. Output is written to a supplied output iterator.
+  ///
+  /// As output code units are generated, they are written to the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param value  A byte of input.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type value, OutputIterator dest) noexcept {
+    switch (state_) {
+    case states::start: dest = this->start_state (value, dest); break;
+    case states::utf8_bom_byte2:
+      buffer_[byte_no (state_)] = value;
+      // Start decoding as UTF-8. If we have a complete UTF-8 BOM drop it, otherwise copy the buffer to output.
+      dest = this->run8_start (value != details::boms[boms_index_from_state (state_)][byte_no (state_)], dest);
+      break;
+
+    case states::utf16_be_bom_byte1:
+      buffer_[byte_no (state_)] = value;
+      // We either have a complete UTF-16 BE BOM in which case we start transcoding or we default to UTF-8 emitting the
+      // bytes consumed so far.
+      dest = (value == details::boms[boms_index_from_state (state_)][byte_no (state_)]) ? this->run16_start (dest)
+                                                                                        : this->run8_start (true, dest);
+      break;
+
+    case states::utf32_or_16_le_bom_byte2:
+      if (value != std::byte{0x00}) {
+        // This isn't a UTF-32 LE BOM but the start of a UTF-16 run.
+        dest = this->run16_start (dest);
+        state_ = states::run_16le_byte1;
+        buffer_[0] = value;
+        break;
+      }
+      [[fallthrough]];
+
+    case states::utf8_bom_byte1:
+    case states::utf32_or_16_le_bom_byte1:
+    case states::utf32_or_16_be_bom_byte1:
+    case states::utf32_be_bom_byte2:
+      buffer_[byte_no (state_)] = value;
+      if (value == details::boms[boms_index_from_state (state_)][byte_no (state_)]) {
+        state_ = next_byte (state_);
+      } else {
+        // Default input encoding. Emit buffer.
+        dest = this->run8_start (true, dest);
+      }
+      break;
+
+    case states::utf32_le_bom_byte3:
+    case states::utf32_be_bom_byte3:
+      assert (byte_no (state_) == 3);
+      buffer_[3] = value;
+      if (value == (is_little_endian (state_) ? std::byte{0x00} : std::byte{0xFF})) {
+        (void)transcoder_variant_.template emplace<t32_type> ();
+        state_ = set_run_mode (set_byte (state_, 0));
+      } else {
+        // Default input encoding. Emit buffer.
+        dest = this->run8_start (true, dest);
+      }
+      break;
+
+    case states::run_16be_byte0:
+    case states::run_16le_byte0:
+    case states::run_32be_byte0:
+    case states::run_32be_byte1:
+    case states::run_32be_byte2:
+    case states::run_32le_byte0:
+    case states::run_32le_byte1:
+    case states::run_32le_byte2:
+      buffer_[byte_no (state_)] = value;
+      state_ = next_byte (state_);
+      break;
+
+    case states::run_8:
+      assert (std::holds_alternative<t8_type> (transcoder_variant_));
+      if (auto* const utf8_input = std::get_if<t8_type> (&transcoder_variant_)) {
+        dest = (*utf8_input) (static_cast<char8> (value), dest);
+      }
+      break;
+
+    case states::run_16be_byte1:
+    case states::run_16le_byte1: dest = this->run16 (value, dest); break;
+
+    case states::run_32be_byte3:
+    case states::run_32le_byte3: dest = this->run32 (value, dest); break;
+    }
+    return dest;
+  }
+
+  /// \brief Call once the entire input sequence has been fed to operator().
+  ///
+  /// This function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  OutputIterator end_cp (OutputIterator dest) noexcept {
+    if (transcoder_variant_.valueless_by_exception ()) {
+      return dest;
+    }
+    return std::visit (
+        [this, &dest] (auto& arg) {
+          if constexpr (std::is_same_v<std::decay_t<decltype (arg)>, std::monostate>) {
+            return this->run8_start (state_ != states::start, dest);
+          } else {
+            return arg.end_cp (dest);
+          }
+        },
+        transcoder_variant_);
+  }
+
+  /// \brief Call once the entire input sequence has been fed to operator().
+  ///
+  /// This function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \brief Returns true if the input represents well formed Unicode.
+  /// \returns True if the input represents well formed Unicode.
+  [[nodiscard]] constexpr bool well_formed () const noexcept;
+
+  /// \brief Return true if a partial code-point has been passed to operator().
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] constexpr bool partial () const noexcept;
+
+  /// \brief The detected encoding of the input stream.
+  /// \returns The encoding of the input stream as detected by consuming an optional leading byte order mark. Initially
+  ///          encoding::unknown.
+  [[nodiscard]] constexpr encoding selected_encoding () const noexcept;
+
+private:
+  /// \anchor transcoder-byte_no
+  /// \param index  The byte number within the BOM encoding. Must be in the range [0,3].
+  /// \returns A value which can be bitwire ORed to represent a particular byte within a BOM encoding.
+  static constexpr std::byte byte_no (std::uint_least8_t index) noexcept {
+    assert (index < 4U);
+    return static_cast<std::byte> (index);
+  }
+
+  /// The number of places to left shift when constructing encoding values for the FSM state enumeration.
+  static constexpr auto encoding_shift = 4U;
+  /// The number of places to left shift when constructing endian values for the FSM state enumeration.
+  static constexpr auto endian_shift = 3U;
+  /// The number of places to left shift when constructing mode values for the FSM state enumeration.
+  static constexpr auto run_shift = 2U;
+
+  static constexpr auto encoding_mask = std::byte{0b11 << encoding_shift};  ///< One of unknown or UTF-8/16/32.
+  static constexpr auto endian_mask = std::byte{1U << endian_shift};        ///< One of big_endian or little_endian.
+  static constexpr auto run_mask = std::byte{1U << run_shift};              ///< Run or bom mode.
+  static constexpr auto byte_no_mask = std::byte{0b11};                     ///< Values from 0-3.
+
+  /// \brief UTF-16 BE or UTF-16 LE encoding.
+  /// \anchor transcoder-encoding_utf16
+  /// Bitwise-or this value to create a state representing UTF-16 (BE or LE) encoding.
+  static constexpr auto encoding_utf16 = std::byte{0b00 << encoding_shift};
+  /// \brief UTF-32 BE or UTF-32 LE encoding.
+  /// \anchor transcoder-encoding_utf32
+  /// Bitwise-or this value to create a state representing UTF-32 (BE or LE) encoding.
+  static constexpr auto encoding_utf32 = std::byte{0b01 << encoding_shift};
+  /// \brief UTF-8 encoding.
+  /// \anchor transcoder-encoding_utf8
+  /// Bitwise-or this value to create a state representing UTF-8 encoding.
+  static constexpr auto encoding_utf8 = std::byte{0b10 << encoding_shift};
+  /// \brief The input encoding is not yet known.
+  static constexpr auto encoding_unknown = std::byte{0b11 << encoding_shift};
+
+  /// \brief Bitwise-or this value to create a state representing the FSM identifying the BOM.
+  /// \anchor transcoder-bom_mode
+  static constexpr auto bom_mode = std::byte{0};
+  /// \brief Bitwise-or this value to create a state representing the FSM consuming runs of bytes and emitting
+  ///        code-units.
+  /// \anchor transcoder-run_mode
+  static constexpr auto run_mode = run_mask;
+
+  /// \brief Bitwise-or this value to create a state consuming big-endian values.
+  /// \anchor transcoder-big_endian
+  static constexpr auto big_endian = std::byte{0};
+  /// \brief Bitwise-or this value to create a state consuming little-endian values.
+  /// \anchor transcoder-little_endian
+  static constexpr auto little_endian = endian_mask;
+
+  /// \brief The states that the finite state machine can occupy.
+  ///
+  /// The values for each state is made from a collection of bits that not only uniquely identify the state, but which
+  /// can be used to share a great deal of code between similar states. For example, the code for handling all but the
+  /// final byte of a UTF-16 BE, UTF-16 LE, UTF-32 BE and UTF-32 LE code unit is shared. We can extract the encoding,
+  /// endianness, and byte numbers from the state codes.
+  ///
+  // clang-format off
+  /// Bit | Interpretation
+  /// --- | --------------
+  /// 0   | 2 bits to describe the encoding being processed: UTF-16 (\link encoding_utf16 \endlink), UTF-32 (\link encoding_utf32 \endlink), UTF-8 (\link encoding_utf8 \endlink), unknown (\link encoding_unknown \endlink). Note that the values are combined with the value of biit 2 (the endianness) to produce an index to the first dimension of the \link details::boms \endlink array.
+  /// 1   | ^
+  /// 2   | 1 bit to identify the input as big (\link big_endian \endlink) or little (\link little_endian \endlink) endian.
+  /// 3   | 1 bit to identify when the state machine is in "Run" or "BOM" mode. In BOM mode (\link bom_mode \endlink), we are in the process of identifying the input encoding. In run mode (\link run_mode \endlink), we are consuming and emitting code-units.
+  /// 4   | 2 bits provide the index of the byte within the BOM that we are processing. This value corresponds to an index into the second dimension of the \link details::boms \endlink array.
+  /// 5   | ^
+  /// 6   | Unused. Always 0.
+  /// 7   | Unused. Always 0.
+  // clang-format on
+  ///
+  /// There are constants which may be bit-wise ORed together to create the appropriate value for each of the FSM's
+  /// states.
+  ///
+  /// \see encoding_utf16, encoding_utf32, encoding_utf8, encoding_unknown, bom_mode, run_mode, big_endian,
+  ///      little_endian, [byte_no(std::uintleast8_t)](\ref transcoder-byte_no).
+
+  enum class states : std::uint_least8_t {
+    /// The FSM's initial state.
+    start = static_cast<std::uint_least8_t> (encoding_unknown | bom_mode | byte_no (0)),
+
+    /// The state if the second byte of a UTF-8 BOM was identified.
+    utf8_bom_byte1 = static_cast<std::uint_least8_t> (encoding_utf8 | big_endian | bom_mode | byte_no (1U)),
+    /// The state if the third byte of a UTF-8 BOM was identified.
+    utf8_bom_byte2 = static_cast<std::uint_least8_t> (encoding_utf8 | big_endian | bom_mode | byte_no (2U)),
+
+    /// The state if the second byte of a UTF-16 BOM was identified.
+    utf16_be_bom_byte1 = static_cast<std::uint_least8_t> (encoding_utf16 | big_endian | bom_mode | byte_no (1U)),
+    /// The state if the third byte of a UTF-32 BE BOM was identified.
+    utf32_be_bom_byte2 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | bom_mode | byte_no (2U)),
+    /// The state if the fourth byte of a UTF-32 BE BOM was identified.
+    utf32_be_bom_byte3 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | bom_mode | byte_no (3U)),
+
+    /// The state if the second byte of a UTF-32 BE or UTF-16 BE BOM was identified.
+    utf32_or_16_be_bom_byte1 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | bom_mode | byte_no (1U)),
+
+    /// The state if the second byte of a UTF-32 LE or UTF-16 LE BOM was identified.
+    utf32_or_16_le_bom_byte1 =
+        static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | bom_mode | byte_no (1U)),
+    /// The state when the state machine is checking for the third byte of a UTF-32 LE BOM or the start of a UTF-16 LE
+    /// run.
+    utf32_or_16_le_bom_byte2 =
+        static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | bom_mode | byte_no (2U)),
+    /// The state when the state machine is checking for the third byte of a UTF-32 LE BOM or the start of a UTF-16 LE
+    /// run.
+    utf32_le_bom_byte3 = static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | bom_mode | byte_no (3U)),
+
+    run_8 = static_cast<std::uint_least8_t> (encoding_utf8 | big_endian | run_mode | byte_no (0U)),
+
+    /// The state when the state machine is handling the first byte of a UTF-16 BE code-unit.
+    run_16be_byte0 = static_cast<std::uint_least8_t> (encoding_utf16 | big_endian | run_mode | byte_no (0U)),
+    /// The state when the state machine is handling the second and final byte of a UTF-32 BE code-unit.
+    run_16be_byte1 = static_cast<std::uint_least8_t> (encoding_utf16 | big_endian | run_mode | byte_no (1U)),
+
+    /// The state when the state machine is handling the first byte of a UTF-16 LE code-unit.
+    run_16le_byte0 = static_cast<std::uint_least8_t> (encoding_utf16 | little_endian | run_mode | byte_no (0U)),
+    /// The state when the state machine is handling the second and final byte of a UTF-32 LE code-unit.
+    run_16le_byte1 = static_cast<std::uint_least8_t> (encoding_utf16 | little_endian | run_mode | byte_no (1U)),
+
+    /// The state when the state machine is handling the first byte of a UTF-32 BE code-unit.
+    run_32be_byte0 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | run_mode | byte_no (0U)),
+    /// The state when the state machine is handling the second byte of a UTF-32 BE code-unit.
+    run_32be_byte1 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | run_mode | byte_no (1U)),
+    /// The state when the state machine is handling the third byte of a UTF-32 BE code-unit.
+    run_32be_byte2 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | run_mode | byte_no (2U)),
+    /// The state when the state machine is handling the fourth and final byte of a UTF-32 BE code-unit.
+    run_32be_byte3 = static_cast<std::uint_least8_t> (encoding_utf32 | big_endian | run_mode | byte_no (3U)),
+
+    /// The state when the state machine is handling the first byte of a UTF-32 LE code-unit.
+    run_32le_byte0 = static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | run_mode | byte_no (0U)),
+    /// The state when the state machine is handling the second byte of a UTF-32 LE code-unit.
+    run_32le_byte1 = static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | run_mode | byte_no (1U)),
+    /// The state when the state machine is handling the third byte of a UTF-32 LE code-unit.
+    run_32le_byte2 = static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | run_mode | byte_no (2U)),
+    /// The state when the state machine is handling the fourth and final byte of a UTF-32 LE code-unit.
+    run_32le_byte3 = static_cast<std::uint_least8_t> (encoding_utf32 | little_endian | run_mode | byte_no (3U)),
+  };
+
+  /// \brief Returns true if the argument represents a state where the FSM is consuming and producing code-units.
+  ///
+  /// \param state  A valid state machine state.
+  /// \returns True if the parameter represents a state where the FSM is consuming and producing code-units.
+  static constexpr bool is_run_mode (states const state) noexcept {
+    return (static_cast<std::byte> (state) & run_mask) == run_mode;
+  }
+  /// \brief Returns true if the argument represents a state in which the FSM is consuming little endian code units.
+  ///
+  /// \param state  A valid state machine state.
+  /// \returns True if the transcoder is consuming little-endian values, false otherwise.
+  static constexpr bool is_little_endian (states const state) noexcept {
+    return (static_cast<std::byte> (state) & endian_mask) == little_endian;
+  }
+
+  /// \brief Extracts the byte number referenced by the argument.
+  ///
+  /// Each of the valid FSM states has an embedded byte number in the range [0..4). This is the current byte of the
+  /// current code unit as it is being assembled by the FSM.
+  ///
+  /// \param state  A valid state machine state.
+  /// \returns The byte number referenced by \p state.
+  static constexpr std::uint_least8_t byte_no (states const state) noexcept {
+    return static_cast<std::uint_least8_t> (static_cast<std::byte> (state) & byte_no_mask);
+  }
+  /// \brief Returns a state which references a specific byte number.
+  ///
+  /// \param state  A valid state machine state. The returned state will be the same as this argument but with the byte
+  ///               number set to \p byte_number.
+  /// \param byte_number The byte to be referenced. Must be in the range [0..4).
+  /// \returns A state referencing the supplied byte number.
+  static constexpr states set_byte (states const state, std::uint_least8_t const byte_number) noexcept {
+    assert (byte_number < 4 && "States must not try to address a byte number > 3");
+    return static_cast<states> ((static_cast<std::byte> (state) & ~byte_no_mask) |
+                                static_cast<std::byte> (byte_number));
+  }
+  /// \brief Returns a state which references the next byte number.
+  ///
+  /// \param state  A valid state machine state. The returned state will be the same as this argument but with the byte
+  ///               number incremented.
+  /// \returns A state referencing the next byte number.
+  static constexpr states next_byte (states const state) noexcept { return set_byte (state, byte_no (state) + 1); }
+
+  /// \brief Adjusts a state so that run mode is selected.
+  ///
+  /// \param state A valid state machine state.
+  /// \returns The modified state.
+  static constexpr states set_run_mode (states const state) noexcept {
+    assert ((static_cast<std::byte> (state) & run_mask) == bom_mode && "Expected a BOM mode state");
+    return static_cast<states> ((static_cast<std::byte> (state) & ~run_mask) | run_mode);
+  }
+
+  /// \brief  Returns an index into the first dimension of the details::boms array from the FSM state value.
+  ///
+  /// The index is based on the encoding and endianness bits of the state.
+  ///
+  /// \param state  The state from which the index is to be extracted.
+  /// \returns  An index into the first dimension of the details::boms array.
+  static constexpr std::size_t boms_index_from_state (states const state) noexcept {
+    auto const state_byte = static_cast<std::byte> (state);
+    assert (((state_byte & (encoding_mask | endian_mask)) >> endian_shift) == (state_byte >> endian_shift));
+    auto const index = static_cast<std::size_t> (state_byte >> endian_shift);
+    assert (index < details::boms.size () && "The index is too large for the BOMs array");
+    return index;
+  }
+
+  /// A short name for the transcoder used when UTF-8 input has been detected.
+  using t8_type = transcoder<icubaby::char8, ToEncoding>;
+  /// A short name for the transcoder used when UTF-16 input has been detected.
+  using t16_type = transcoder<char16_t, ToEncoding>;
+  /// A short name for the transcoder used when UTF-32 input has been detected.
+  using t32_type = transcoder<char32_t, ToEncoding>;
+
+  /// The current state of the FSM.
+  states state_ = states::start;
+  /// A buffer into which input bytes are gathered as a complete code unit is being assembled by the state machine.
+  std::array<std::byte, 4> buffer_{};
+  /// Holds the transcoder used to convert input code units. Holds monostate until the input encoding has been selected.
+  std::variant<std::monostate, t8_type, t16_type, t32_type> transcoder_variant_;
+
+  /// \brief A helper for ensuring that a type will not cause variant_ to become valueless by exception.
+  ///
+  /// We must ensure that the transcoder_variant_ member cannot be in the valueless by exception state. This means that
+  /// construction and assignment to the variant must never throw. This type is a helper to verify that a type cannot
+  /// throw during default, copy, or move construction as well as copy or move assignment.
+  template <typename T>
+  struct is_nothrowable
+      : std::bool_constant<std::is_nothrow_constructible_v<T> && std::is_nothrow_copy_constructible_v<T> &&
+                           std::is_nothrow_move_constructible_v<T> && std::is_nothrow_copy_assignable_v<T> &&
+                           std::is_nothrow_move_assignable_v<T>> {};
+  static_assert (is_nothrowable<std::monostate>::value);
+  static_assert (is_nothrowable<t8_type>::value);
+  static_assert (is_nothrowable<t16_type>::value);
+  static_assert (is_nothrowable<t32_type>::value);
+
+  /// Handles the initial state of the FSM. Checks the inital input byte against the collection of potential byte order
+  /// mark initial bytes and decides on the next action.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param value  The initial input byte.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  [[nodiscard]] OutputIterator start_state (input_type const value, OutputIterator dest) noexcept {
+    buffer_[0] = value;
+    if (value == std::byte{0xEF}) {
+      state_ = states::utf8_bom_byte1;
+    } else if (value == std::byte{0xFE}) {
+      state_ = states::utf16_be_bom_byte1;
+    } else if (value == std::byte{0xFF}) {
+      state_ = states::utf32_or_16_le_bom_byte1;
+    } else if (value == std::byte{0x00}) {
+      state_ = states::utf32_or_16_be_bom_byte1;
+    } else {
+      dest = this->run8_start (true, dest);
+    }
+    return dest;
+  }
+
+  /// Switches to the run state in which the input has been determined to be UTF-8 encoded.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param copy_buffer  True if the contents of buffer_ should be copied immediately to the output.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  [[nodiscard]] OutputIterator run8_start (bool const copy_buffer, OutputIterator dest) noexcept {
+    assert (!is_run_mode (state_) && "The FSM should not be in run mode when run8_start is called");
+    assert (std::holds_alternative<std::monostate> (transcoder_variant_) &&
+            "The variant should hold monostate until the FSM is in run mode");
+    auto& trans = transcoder_variant_.template emplace<t8_type> ();
+    if (copy_buffer) {
+      // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+      auto const first = std::begin (buffer_);
+      (void)std::for_each (first, first + byte_no (state_) + 1,
+                           [&trans, &dest] (std::byte value) { dest = trans (static_cast<char8> (value), dest); });
+    }
+    state_ = states::run_8;
+    return dest;
+  }
+
+  /// Switches to the run state in which the input has been determined to be UTF-16 encoded.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  [[nodiscard]] OutputIterator run16_start (OutputIterator dest) noexcept {
+    assert (!is_run_mode (state_) && "The FSM should not be in run mode when run16_start is called");
+    assert (std::holds_alternative<std::monostate> (transcoder_variant_) &&
+            "The variant should hold monostate until the FSM is in run mode");
+    (void)transcoder_variant_.template emplace<t16_type> ();
+    state_ = is_little_endian (state_) ? states::run_16le_byte0 : states::run_16be_byte0;
+    return dest;
+  }
+
+  /// \brief Handler for the states::run_16be_byte1 and states::run_16le_byte1 states.
+  ///
+  /// This function is called once we have received the second byte of a UTF-16 code unit. We build the native-endian
+  /// version of the 16-bit value and pass it to the transcoder which will be expecting UTF-16. The FSM is then reset
+  /// to expect byte 0 of the next code unit.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param value  The final byte of the 16-bit code unit.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  [[nodiscard]] OutputIterator run16 (input_type const value, OutputIterator dest) noexcept {
+    assert (state_ == states::run_16be_byte1 || state_ == states::run_16le_byte1);
+    assert (std::holds_alternative<t16_type> (transcoder_variant_));
+
+    if (auto* const utf16_input = std::get_if<t16_type> (&transcoder_variant_)) {
+      dest = (*utf16_input) (state_ == states::run_16be_byte1 ? char16_from_big_endian_buffer (value)
+                                                              : char16_from_little_endian_buffer (value),
+                             dest);
+    }
+    state_ = set_byte (state_, 0);
+    return dest;
+  }
+
+  /// \brief Handler for the state::run_32be_byte3 and state::run_32le_byte3 states.
+  ///
+  /// This function is called once we have received all four bytes of a UTF-32 code unit. We build the native-endian
+  /// version of the 32-bit value and pass it to the transcoder which will be expecting UTF-32. The FSM is then reset
+  /// to expect byte 0 of the next code unit.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param value  The final byte of the 32-bit code unit.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (ToEncoding) OutputIterator>
+  [[nodiscard]] OutputIterator run32 (input_type const value, OutputIterator dest) noexcept {
+    assert (state_ == states::run_32be_byte3 || state_ == states::run_32le_byte3);
+    assert (std::holds_alternative<t32_type> (transcoder_variant_));
+
+    if (auto* const utf32_input = std::get_if<t32_type> (&transcoder_variant_)) {
+      dest = (*utf32_input) (state_ == states::run_32be_byte3 ? char32_from_big_endian_buffer (value)
+                                                              : char32_from_little_endian_buffer (value),
+                             dest);
+    }
+    state_ = set_byte (state_, 0);
+    return dest;
+  }
+
+  /// \brief Produces a native-endian 16-bit value from big endian encoded input by combining the first entry in the
+  ///        buffer_ array with \p value.
+  ///
+  /// \param value An input byte
+  /// \returns A native-endian 16 bit value.
+  [[nodiscard]] constexpr char16_t char16_from_big_endian_buffer (input_type const value) const noexcept {
+    return static_cast<char16_t> ((static_cast<std::uint_least16_t> (buffer_[0]) << 8U) |
+                                  static_cast<std::uint_least16_t> (value));
+  }
+  /// \brief Produces a native-endian 16-bit value from little endian encoded input by combining the first entry in the
+  ///        buffer_ array with \p value.
+  ///
+  /// \param value An input byte
+  /// \returns A native-endian 16 bit value.
+  [[nodiscard]] constexpr char16_t char16_from_little_endian_buffer (input_type const value) const noexcept {
+    return static_cast<char16_t> ((static_cast<std::uint_least16_t> (value) << 8U) |
+                                  static_cast<std::uint_least16_t> (buffer_[0]));
+  }
+  /// \brief Produces a native-endian 32-bit value from big endian encoded input by combining the entries in the
+  ///        buffer_ array with \p value.
+  ///
+  /// \param value An input byte
+  /// \returns A native-endian 32 bit value.
+  [[nodiscard]] constexpr char32_t char32_from_big_endian_buffer (input_type const value) const noexcept {
+    return static_cast<char32_t> ((static_cast<std::uint_least32_t> (buffer_[0]) << 24U) |
+                                  (static_cast<std::uint_least32_t> (buffer_[1]) << 16U) |
+                                  (static_cast<std::uint_least32_t> (buffer_[2]) << 8U) |
+                                  static_cast<std::uint_least32_t> (value));
+  }
+  /// \brief Produces a native-endian 32-bit value from little endian encoded input by combining the entries in the
+  ///        buffer_ array with \p value.
+  ///
+  /// \param value An input byte
+  /// \returns A native-endian 32 bit value.
+  [[nodiscard]] constexpr char32_t char32_from_little_endian_buffer (input_type const value) const noexcept {
+    return static_cast<char32_t> (
+        (static_cast<std::uint_least32_t> (value << 24U)) | (static_cast<std::uint_least32_t> (buffer_[2]) << 16U) |
+        (static_cast<std::uint_least32_t> (buffer_[1]) << 8U) | (static_cast<std::uint_least32_t> (buffer_[0])));
+  }
+};
+
+// partial
+// ~~~~~~~
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+constexpr bool transcoder<std::byte, ToEncoding>::partial () const noexcept {
+  // We ensure thaat the variant cannot ever become stateless. This check is belt and braces to guarantee that
+  // std::visit() cannot throw.
+  if (transcoder_variant_.valueless_by_exception ()) {
+    return false;
+  }
+  return std::visit (
+      [this] (auto const& arg) {
+        if constexpr (std::is_same_v<std::decay_t<decltype (arg)>, std::monostate>) {
+          return this->state_ != states::start;
+        } else {
+          return arg.partial ();
+        }
+      },
+      transcoder_variant_);
+}
+
+// well formed
+// ~~~~~~~~~~~
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+constexpr bool transcoder<std::byte, ToEncoding>::well_formed () const noexcept {
+  if (transcoder_variant_.valueless_by_exception ()) {
+    return true;
+  }
+  return std::visit (
+      [] (auto const& arg) {
+        if constexpr (std::is_same_v<std::decay_t<decltype (arg)>, std::monostate>) {
+          return true;
+        } else {
+          return arg.well_formed ();
+        }
+      },
+      transcoder_variant_);
+}
+
+// selected encoding
+// ~~~~~~~~~~~~~~~~~
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+constexpr encoding transcoder<std::byte, ToEncoding>::selected_encoding () const noexcept {
+  encoding result = encoding::unknown;
+  if (is_run_mode (state_)) {
+    switch (static_cast<std::uint_least8_t> (static_cast<std::byte> (state_) & encoding_mask)) {
+    case static_cast<std::uint_least8_t> (encoding_unknown):
+      assert (false && "We must know the encoding when in run mode");
+      result = encoding::unknown;
+      break;
+    case static_cast<std::uint_least8_t> (encoding_utf8): result = encoding::utf8; break;
+    case static_cast<std::uint_least8_t> (encoding_utf16):
+      result = is_little_endian (state_) ? encoding::utf16le : encoding::utf16be;
+      break;
+    case static_cast<std::uint_least8_t> (encoding_utf32):
+      result = is_little_endian (state_) ? encoding::utf32le : encoding::utf32be;
+      break;
+    }
+  }
+  return result;
+}
+
+namespace details {
+
+/// \brief The maximum number of code units produced as the intermediate output from the triangulator's conversion to
+///        UTF-32.
+///
+/// The maximum number of code units produced from a single input code unit can vary (particularly if the input is
+/// malformed).
+///
+/// \tparam FromEncoding  The soure encoding.
+/// \tparam ToEncoding  The destination encoding.
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE FromEncoding, ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+struct triangulator_intermediate_code_units : public std::integral_constant<std::size_t, 1> {};
+/// \brief The maximum number of code units produced when converting from UTF-16.
+/// \tparam ToEncoding  The destination encoding.
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+struct triangulator_intermediate_code_units<char16_t, ToEncoding> : public std::integral_constant<std::size_t, 2> {};
+
+/// \brief A "triangulator" converts from the \p FromEncoding encoding to the \p ToEncoding encoding via an
+///        intermediate UTF-32 encoding.
+///
+/// \tparam FromEncoding  The soure encoding.
+/// \tparam ToEncoding  The destination encoding.
+template <ICUBABY_CONCEPT_UNICODE_CHAR_TYPE FromEncoding, ICUBABY_CONCEPT_UNICODE_CHAR_TYPE ToEncoding>
+class triangulator {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = FromEncoding;
+  /// The type of the code units produced by this transcoder.
+  using output_type = ToEncoding;
+
+  /// Accepts a code unit in the source encoding (as given by triangulator::input_type). These are first converted
+  /// to UTF-32 and then to the output encoding (double_transcover::output_type). As output code units are generated,
+  /// they are written to the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param code_unit  A code unit in the source encoding.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) {
+    // The (intermediate) output from the conversion to UTF-32. It's possible
+    // for the transcoder to produce more than a single output code unit if the
+    // input is malformed.
+    std::array<char32_t, triangulator_intermediate_code_units<FromEncoding, ToEncoding>::value> intermediate{};
+    // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+    auto const begin = std::begin (intermediate);
+    return copy (begin, intermediate_ (code_unit, begin), dest);
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator> OutputIterator end_cp (OutputIterator dest) {
+    std::array<char32_t, triangulator_intermediate_code_units<FromEncoding, ToEncoding>::value> intermediate{};
+    // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+    auto const first = std::begin (intermediate);
+    // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+    auto const last = intermediate_.end_cp (first);
+    assert (last >= first && last <= std::end (intermediate));
+    return output_.end_cp (this->copy (first, last, dest));
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder<FromEncoding, ToEncoding>, OutputIterator> end_cp (
+      iterator<transcoder<FromEncoding, ToEncoding>, OutputIterator> dest) {
+    auto const tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input passed to operator() was valid.
+  [[nodiscard]] constexpr bool well_formed () const noexcept {
+    return intermediate_.well_formed () && output_.well_formed ();
+  }
+
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] constexpr bool partial () const noexcept { return intermediate_.partial (); }
+
+private:
+  /// We use the intermediate_ transcoder to convert from the input encoding to UTF-32.
+  transcoder<input_type, char32_t> intermediate_;
+  /// The output_ transcoder converts from the intermediate (UTF-32) encoding to the selected output encoding.
+  transcoder<char32_t, output_type> output_;
+
+  /// Copies the range [first, last) to the output iterator \p dest via the output_ transcoder.
+  ///
+  /// \param first  The first of the range to copy.
+  /// \param last  The last of the range to copy.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <typename InputIterator, typename OutputIterator>
+  OutputIterator copy (InputIterator first, InputIterator last, OutputIterator dest) {
+    (void)std::for_each (first, last, [this, &dest] (char32_t const code_unit) { dest = output_ (code_unit, dest); });
+    return dest;
+  }
+};
+
+}  // end namespace details
+
+/// Takes a sequence of UTF-8 code units and converts them to UTF-16.
+template <> class transcoder<char8, char16_t> : public details::triangulator<char8, char16_t> {};
+/// Takes a sequence of UTF-16 code units and converts them to UTF-8.
+template <> class transcoder<char16_t, char8> : public details::triangulator<char16_t, char8> {};
+/// Takes a sequence of UTF-8 code units and converts them to UTF-8.
+template <> class transcoder<char8, char8> : public details::triangulator<char8, char8> {};
+/// Takes a sequence of UTF-16 code units and converts them to UTF-16.
+template <> class transcoder<char16_t, char16_t> : public details::triangulator<char16_t, char16_t> {};
+/// Takes a sequence of UTF-32 code units and converts them to UTF-32.
+template <> class transcoder<char32_t, char32_t> {
+public:
+  /// The type of the code units consumed by this transcoder.
+  using input_type = char32_t;
+  /// The type of the code units produced by this transcoder.
+  using output_type = char32_t;
+
+  /// Accepts a code unit in the UTF-32 source encoding. As UTF-32 output code units are generated, they are written to
+  /// the output iterator \p dest.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of
+  ///   output_type can be written.
+  /// \param code_unit  A UTF-32 code unit,
+  /// \param dest  Iterator to which the output should be written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  OutputIterator operator() (input_type code_unit, OutputIterator dest) {
+    // From D90 in Chapter 3 of Unicode 15.0.0
+    // <https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf>:
+    //
+    // "Because surrogate code points are not included in the set of Unicode
+    // scalar values, UTF-32 code units in the range 0000D80016..0000DFFF16 are
+    // ill-formed. Any UTF-32 code unit greater than 0x0010FFFF is ill-formed."
+    if (code_unit > max_code_point || is_surrogate (code_unit)) {
+      well_formed_ = false;
+      code_unit = replacement_char;
+    }
+    *(dest++) = code_unit;
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  The output iterator.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr OutputIterator end_cp (OutputIterator dest) const {
+    return dest;
+  }
+
+  /// Call once the entire input sequence has been fed to operator(). This
+  /// function ensures that the sequence did not end with a partial code point.
+  ///
+  /// \tparam OutputIterator  An output iterator type to which values of type output_type can be written.
+  /// \param dest  An output iterator to which the output sequence is written.
+  /// \returns  Iterator one past the last element assigned.
+  template <ICUBABY_CONCEPT_OUTPUT_ITERATOR (output_type) OutputIterator>
+  constexpr iterator<transcoder, OutputIterator> end_cp (iterator<transcoder, OutputIterator> dest) {
+    auto tcdr = dest.transcoder ();
+    assert (tcdr == this);
+    return {tcdr, tcdr->end_cp (dest.base ())};
+  }
+
+  /// \returns True if the input represented well formed UTF-32.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+  /// \returns True if a partial code-point has been passed to operator() and
+  /// false otherwise.
+  [[nodiscard]] static constexpr bool partial () noexcept { return false; }
+
+private:
+  /// True if the input consumed is well formed, false otherwise.
+  bool well_formed_ = true;
+};
+
+/// \brief A shorter name for the UTF-8 to UTF-8 transcoder.
+/// This, assuming well-formed input, represents no change.
+using t8_8 = transcoder<char8, char8>;
+/// A shorter name for the UTF-8 to UTF-16 transcoder.
+using t8_16 = transcoder<char8, char16_t>;
+/// A shorter name for the UTF-8 to UTF-32 transcoder.
+using t8_32 = transcoder<char8, char32_t>;
+/// A shorter name for the UTF-16 to UTF-8 transcoder.
+using t16_8 = transcoder<char16_t, char8>;
+/// \brief A shorter name for the UTF-16 to UTF-16 transcoder.
+/// This, assuming well-formed input, represents no change.
+using t16_16 = transcoder<char16_t, char16_t>;
+/// A shorter name for the UTF-16 to UTF-32 transcoder.
+using t16_32 = transcoder<char16_t, char32_t>;
+
+/// A shorter name for the UTF-32 to UTF-8 transcoder.
+using t32_8 = transcoder<char32_t, char8>;
+/// A shorter name for the UTF-32 to UTF-16 transcoder.
+using t32_16 = transcoder<char32_t, char16_t>;
+/// \brief A shorter name for the UTF-32 to UTF-32 transcoder.
+/// This, assuming well-formed input, represents no change.
+using t32_32 = transcoder<char32_t, char32_t>;
+
+/// A shorter name for the UTF-8 "byte transcoder" which consumes bytes in unknown input encoding and produces UTF-8.
+using tx_8 = transcoder<std::byte, char8>;
+/// A shorter name for the UTF-16 "byte transcoder" which consumes bytes in unknown input encoding and produces UTF-16.
+using tx_16 = transcoder<std::byte, char16_t>;
+/// A shorter name for the UTF-32 "byte transcoder" which consumes bytes in unknown input encoding and produces UTF-32.
+using tx_32 = transcoder<std::byte, char32_t>;
+
+#if ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+/// \brief icubaby C++ 20 ranges support types.
+namespace ranges {
+
+/// \brief A range adaptor for lazily converting between Unicode encodings.
+///
+/// A range adaptor that represents view of an underlying sequence consisting of Unicode code points in the encoding
+/// given by FromEncoding and produces the equivalent code points in the encoding given by ToEncoding.
+///
+/// \tparam FromEncoding  The encoding used by the underlying sequence.
+/// \tparam ToEncoding  The encoding that will be produced by this range adaptor.
+/// \tparam View  The type of the underlying view.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
+  requires std::ranges::view<View>
+class transcode_view : public std::ranges::view_interface<transcode_view<FromEncoding, ToEncoding, View>> {
+public:
+  class iterator;
+  class sentinel;
+
+  /// \brief Default initializes the base view of a new transcode_view instance.
+  transcode_view () requires std::default_initializable<View> = default;
+  /// \brief Initializes the base view of a new transcode_view instance.
+  constexpr explicit transcode_view (View base) : base_ (std::move (base)) {}
+
+  /// \returns The base view.
+  constexpr View base () const& requires std::copy_constructible<View> { return base_; }
+  /// \returns Moves the base view out of this object.
+  constexpr View base () && { return std::move (base_); }
+
+  /// \brief Obtains the beginning iterator of a transcode_view.
+  constexpr auto begin () const { return iterator{*this, std::ranges::begin (base_)}; }
+  /// \brief Obtains the sentinel denoting the end of transcode_view.
+  constexpr auto end () const {
+    if constexpr (std::ranges::common_range<View>) {
+      return iterator{*this, std::ranges::end (base_)};
+    } else {
+      return sentinel{*this};
+    }
+  }
+
+  /// \returns True if the input processed was well formed.
+  [[nodiscard]] constexpr bool well_formed () const noexcept { return well_formed_; }
+
+private:
+  /// The underlying view from which input is drawn.
+  ICUBABY_NO_UNIQUE_ADDRESS View base_ = View ();
+  /// True if the input consumed is well formed, false otherwise.
+  mutable bool well_formed_ = true;
+};
+
+/// The maximum number of bytes that can be produced by a single code-unit being passed to a transcoder.
+template <typename FromEncoding, typename ToEncoding>
+inline constexpr auto max_output_bytes = longest_sequence_v<ToEncoding>;
+
+/// \brief The maximum number of bytes produced by a single code-unit being passed to a transcoder consuming UTF-16.
+///
+/// The value six comes from the worst-case output which happens when converting a code-units
+/// char16_t{0xD902}, char16_t{0xFFFF} (that is a high surrogate followed by the maximum 16-bit value). This will
+/// cause the second invocation of the UTF-16 to UTF-8 transcoder to produce the REPLACEMENT CHAR and "Not a Character"
+/// code-points which are each 3 bytes when encoded as UTF-8.
+template <> inline constexpr auto max_output_bytes<char16_t, icubaby::char8> = std::size_t{6};
+
+/// \brief The maximum number of bytes produced by a single code-unit being passed to a transcoder consuming UTF-32.
+template <> inline constexpr auto max_output_bytes<char16_t, char32_t> = std::size_t{2};
+
+/// \brief The iterator type of transcode_view.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
+  requires std::ranges::view<View>
+class transcode_view<FromEncoding, ToEncoding, View>::iterator {
+public:
+  /// Defines this class as fulfilling the requirements of a forward iterator.
+  using iterator_category = std::forward_iterator_tag;
+  /// Define this class as following the forward iterator concept.
+  using iterator_concept = std::forward_iterator_tag;
+
+  /// The type produced by this iterator.
+  using value_type = ToEncoding;
+
+  /// A type that can be used to identify distance between iterators.
+  using difference_type = std::ranges::range_difference_t<View>;
+
+  iterator () requires std::default_initializable<std::ranges::iterator_t<View>> = default;
+  constexpr iterator (transcode_view const& parent, std::ranges::iterator_t<View const> const& current)
+      : current_{current}, parent_{&parent}, state_{current} {
+    assert (state_.empty ());
+    // Prime the input state so that a dereference of the iterator will yield the first of the
+    // output code-units.
+    if (current != std::ranges::end (parent_->base_)) {
+      current_ = state_.fill (parent_);
+    }
+  }
+
+  /// \brief Returns the underlying view
+  constexpr std::ranges::iterator_t<View> const& base () const& noexcept { return current_; }
+  /// \brief Returns the underlying view
+  constexpr std::ranges::iterator_t<View> base () && { return std::move (current_); }
+
+  constexpr value_type const& operator* () const { return state_.front (); }
+  constexpr std::ranges::iterator_t<View> operator->() const { return state_.front (); }
+
+  constexpr iterator& operator++ () {
+    state_.advance ();
+    if (state_.empty ()) {
+      // We've exhausted the stashed output code units. Refill the buffer and reset.
+      current_ = state_.fill (parent_);
+    }
+    return *this;
+  }
+  constexpr void operator++ (int) { ++*this; }
+  constexpr iterator operator++ (int) requires std::ranges::forward_range<View> {
+    auto result = *this;
+    ++*this;
+    return result;
+  }
+
+  friend constexpr bool operator== (iterator const& lhs, iterator const& rhs)
+    requires std::equality_comparable<std::ranges::iterator_t<View>>
+  {
+    return lhs.current_ == rhs.current_ && lhs.parent_ == rhs.parent_;
+  }
+
+private:
+  /// \brief The state class is responsible for transforming the input values to output code units.
+  ///
+  /// It maintains a code point's worth of output code units in its internal buffer. These may be accessed by the
+  /// owning iterator using the front() and advance() member functions. Once the buffer is empty, it is refilled using
+  /// the fill() function.
+  class state {
+  public:
+    /// \brief Initializes the state and primes the internal buffer with an initial code-point read from the input.
+    ///
+    /// \param iter  An iterator referencing the next element in the input range to be consumed.
+    constexpr explicit state (std::ranges::iterator_t<View const> iter) : next_{std::move (iter)} {}
+    constexpr state () = default;
+
+    /// Returns true if the output buffer is empty and false otherwise.
+    [[nodiscard]] constexpr bool empty () const noexcept {
+      assert (first_ <= last_ && last_ <= out_.size () && "first_ and last_ must be valid indexes in the out_ array");
+      return first_ == last_;
+    }
+
+    /// Returns the first element from the range of code units forming the current code point.
+    [[nodiscard]] constexpr auto& front () const noexcept {
+      assert (!this->empty () && "The out_ array must not be empty when front() is called");
+      return out_[first_];
+    }
+
+    /// Removes the first element from the range of code units forming the current code point.
+    constexpr void advance () noexcept {
+      assert (!this->empty () && "The out_ array must not be empty when advance() is called");
+      ++first_;
+    }
+
+    /// \brief Consumes enough code-units from the base iterator to form a single code-point.
+    ///
+    /// The resulting code-units in the output encoding can be sequentially accessed using the front() and
+    /// advance() methods.
+    ///
+    /// \param parent  The view from which input values are to be consumed.
+    /// \returns The updated base iterator.
+    constexpr std::ranges::iterator_t<View const> fill (transcode_view const* parent);
+
+  private:
+    /// The type of the output buffer. This is sized so that it allows for the largest nunber of bytes that the
+    /// transcoder can produce.
+    using out_type = std::array<ToEncoding, max_output_bytes<FromEncoding, ToEncoding>>;
+    /// Output buffer iterator type.
+    using iterator = typename out_type::iterator;
+
+    /// An iterator referencing the next input code-unit to be consumed.
+    std::ranges::iterator_t<View const> next_{};
+    /// The container into which the transcoder's output will be written.
+    out_type out_{};
+    /// The transcoder used to convert a series of code-units in the source encoding to the destination encoding.
+    transcoder<FromEncoding, ToEncoding> transcoder_;
+
+    /// The number of bits allocated for the first_ and last_ members.
+    /// Must be enough to represent all valid indexes in out_type.
+    static constexpr auto valid_range_bits = 4U;
+    static_assert (out_type{}.size () < std::size_t{1} << valid_range_bits,
+                   "There are not sufficient bits to represent indexes in out_type");
+
+    /// \brief The index of the start of the valid range of code units in the state::out_ container.
+    ///
+    /// Together with the last_ field, determines the code-units to be produced when the view is dereferenced.
+    std::uint_least8_t first_ : valid_range_bits = 0;
+    /// \brief The index one beyond the end of the the valid range of code units in the state::out_ container.
+    ///
+    /// Together with the last_ field, determines the code-units to be produced when the view is dereferenced.
+    std::uint_least8_t last_ : valid_range_bits = 0;
+  };
+  std::ranges::iterator_t<View const> current_{};
+  transcode_view const* parent_ = nullptr;
+  mutable state state_{};
+};
+
+template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
+  requires std::ranges::view<View>
+constexpr std::ranges::iterator_t<View const> transcode_view<FromEncoding, ToEncoding, View>::iterator::state::fill (
+    transcode_view const* parent) {
+  auto result = next_;
+  assert (this->empty () && "out_ was not empty when fill called");
+
+  auto const out_begin = out_.begin ();
+  auto out_it = out_begin;
+  auto const input_end = std::ranges::end (parent->base_);
+  // Loop until we've produced a code-point's worth of code-units in the out
+  // container or we've run out of input.
+  while (out_it == out_begin && next_ != input_end) {
+    out_it = transcoder_ (*next_, out_it);
+    assert (out_it >= out_begin && out_it <= out_.end () && "out_ buffer overflow!");
+    ++next_;
+  }
+  if (next_ == input_end) {
+    // We've consumed the entire input so tell the transcoder and get any final output.
+    out_it = transcoder_.end_cp (out_it);
+  }
+  assert (out_it >= out_begin && out_it <= out_.end () && "out_ buffer overflow!");
+  if (!transcoder_.well_formed ()) {
+    parent->well_formed_ = false;
+  }
+  first_ = std::uint_least8_t{0};
+  last_ = static_cast<std::uint_least8_t> (out_it - out_begin);
+  return result;
+}
+
+/// \brief The sentinel type of transcode_view when the underlying view is not a common_range.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::input_range View>
+  requires std::ranges::view<View>
+class transcode_view<FromEncoding, ToEncoding, View>::sentinel {
+public:
+  sentinel () = default;
+  /// Derives the value of this sentinel instance from the end of the associated view.
+  constexpr explicit sentinel (transcode_view const& parent) : end_{std::ranges::end (parent.base_)} {}
+  /// \returns The underlying view's end sentinel
+  constexpr std::ranges::sentinel_t<View> base () const { return end_; }
+  /// \brief Compares and iterator and sentinal for equality.
+  friend constexpr bool operator== (iterator const& lhs, sentinel const& rhs) { return lhs.base () == rhs.end_; }
+
+private:
+  std::ranges::sentinel_t<View> end_{};  ///< The underlying view's end sentinel
+};
+
+namespace views {
+
+/// \tparam FromEncoding  The encoding used by the underlying sequence.
+/// \tparam ToEncoding  The encoding that will be produced by this adaptor.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding> class transcode_range_adaptor {
+public:
+  template <std::ranges::viewable_range Range> constexpr auto operator() (Range&& range) const {
+    return transcode_view<FromEncoding, ToEncoding, std::ranges::views::all_t<Range>>{std::forward<Range> (range)};
+  }
+};
+
+/// \tparam FromEncoding  The encoding used by the underlying sequence.
+/// \tparam ToEncoding  The encoding that will be produced.
+/// \tparam Range  The type of the range that will be consumed.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding, std::ranges::viewable_range Range>
+constexpr auto operator| (Range&& range, transcode_range_adaptor<FromEncoding, ToEncoding> const& adaptor) {
+  return adaptor (std::forward<Range> (range));
+}
+
+/// \tparam FromEncoding  The encoding used by the underlying sequence.
+/// \tparam ToEncoding  The encoding that will be produced.
+template <unicode_input FromEncoding, unicode_char_type ToEncoding>
+inline constexpr auto transcode = views::transcode_range_adaptor<FromEncoding, ToEncoding>{};
+
+}  // end namespace views
+
+}  // end namespace ranges
+
+namespace views = ranges::views;
+#endif  // ICUBABY_HAVE_RANGES && ICUBABY_HAVE_CONCEPTS
+
+}  // end namespace icubaby
+
+#ifdef ICUBABY_INSIDE_NS
+}  // end namespace ICUBABY_INSIDE_NS
+#endif
+
+#endif  // ICUBABY_ICUBABY_HPP

--- a/include/uri/parts.hpp
+++ b/include/uri/parts.hpp
@@ -13,14 +13,26 @@
 #ifndef URI_PARTS_HPP
 #define URI_PARTS_HPP
 
+#include <bitset>
+
 #include "uri/icubaby.hpp"
+#include "uri/pctdecode.hpp"
 #include "uri/pctencode.hpp"
 #include "uri/punycode.hpp"
 #include "uri/uri.hpp"
 
 namespace uri {
 
-enum class parts_field { scheme, userinfo, host, port, path, query, fragment };
+enum class parts_field : std::uint_least8_t {
+  scheme,
+  userinfo,
+  host,
+  port,
+  path,
+  query,
+  fragment,
+  last
+};
 
 constexpr pctencode_set pctencode_set_from_parts_field (
   parts_field const field) noexcept {
@@ -32,6 +44,7 @@ constexpr pctencode_set pctencode_set_from_parts_field (
   case parts_field::host:
   case parts_field::port:
   case parts_field::scheme:
+  case parts_field::last:
   default: return pctencode_set::none;
   }
 }
@@ -56,6 +69,7 @@ private:
 
 std::size_t pct_encoded_size (std::string_view const str,
                               pctencode_set const encodeset);
+std::size_t pct_decoded_size (std::string_view const str);
 
 template <typename Function>
   requires std::is_invocable_r_v<std::string_view, Function, std::string_view,
@@ -134,23 +148,46 @@ puny_encoded_result<OutputIterator> puny_encoded (Range&& range,
   return {std::move (out), any_needed};
 }
 
+template <std::ranges::input_range Range>
+  requires std::is_same_v<
+    std::remove_cv_t<typename std::ranges::range_value_t<Range>>, char32_t>
+std::size_t puny_encoded_size (Range&& range) {
+  details::ro_sink_container<char> sink;
+  return puny_encoded (std::forward<Range> (range), std::back_inserter (sink))
+             .any_non_ascii
+           ? sink.size ()
+           : std::size_t{0};
+}
+
+template <std::output_iterator<char8_t> OutputIterator>
+struct puny_decoded_result {
+  OutputIterator out;
+  bool any_encoded = false;
+};
+
+template <std::output_iterator<char8_t> OutputIterator>
+puny_decoded_result (OutputIterator,
+                     bool) -> puny_decoded_result<OutputIterator>;
+
 template <std::ranges::bidirectional_range Range,
-          std::output_iterator<char32_t> OutputIterator>
+          std::output_iterator<char8_t> OutputIterator>
   requires std::is_same_v<std::ranges::range_value_t<Range>, char>
-std::error_code puny_decoded (Range&& range, OutputIterator out) {
-  using namespace std::string_view_literals;
+std::variant<std::error_code, puny_decoded_result<OutputIterator>>
+puny_decoded (Range&& range, OutputIterator out) {
   using std::ranges::subrange;
-  auto const end = std::ranges::end (range);
+  auto const last = std::ranges::end (range);
+  bool any_encoded = false;
 
   auto const find_dot = std::views::take_while (is_not_dot);
-  auto view = subrange{std::ranges::begin (range), end} | find_dot;
+  auto view = subrange{std::ranges::begin (range), last} | find_dot;
+  auto first = std::ranges::begin (view);
 
   for (;;) {
     if (starts_with (view, punycode_prefix)) {
-      auto b = std::ranges::begin (view);
-      std::ranges::advance (b, punycode_prefix.size ());
+      any_encoded = true;
+      std::ranges::advance (first, punycode_prefix.size ());
 
-      auto const component = subrange{b, std::ranges::end (view)};
+      auto const component = subrange{first, std::ranges::end (view)};
       std::string str2;
       std::ranges::copy (component, std::back_inserter (str2));
 
@@ -159,38 +196,47 @@ std::error_code puny_decoded (Range&& range, OutputIterator out) {
         return *erc;
       }
       auto const& [_, out_] =
-        std::ranges::copy (std::get<std::u32string> (decode_res), out);
+        std::ranges::copy (std::get<std::u32string> (decode_res) |
+                             icubaby::views::transcode<char32_t, char8_t>,
+                           out);
       out = std::move (out_);
 
-      std::ranges::advance (b, str2.size () + 1);
-      auto in = b;
-      if (in == end) {
+      std::ranges::advance (
+        first, static_cast<std::iter_difference_t<decltype (first)>> (
+                 str2.size () + 1U));
+      if (first == last) {
         break;
       }
-      view = subrange{in, end} | find_dot;
     } else {
-      auto const& [in, out_] = std::ranges::copy (view, out);
-      out = out_;
-      if (in == end) {
+      auto const& [first_, out_] = std::ranges::copy (view, out);
+      first = std::move (first_);
+      out = std::move (out_);
+      if (first == last) {
         break;
       }
-      view = subrange{std::next (in), end} | find_dot;
+      first = std::next (first);
     }
-
-    (*out++) = '.';
+    view = subrange{first, last} | find_dot;
+    *(out++) = '.';
   }
 
-  return {};
+  return puny_decoded_result{out, any_encoded};
 }
 
-template <std::ranges::input_range Range>
-  requires std::is_same_v<
-    std::remove_cv_t<typename std::ranges::range_value_t<Range>>, char32_t>
-std::size_t puny_encoded_size (Range&& range) {
+template <std::ranges::bidirectional_range Range>
+  requires std::is_same_v<std::ranges::range_value_t<Range>, char>
+std::variant<std::error_code, std::size_t> puny_decoded_size (Range&& range) {
   details::ro_sink_container<char> sink;
-  return puny_encoded (range, std::back_inserter (sink)).any_non_ascii
-           ? sink.size ()
-           : std::size_t{0};
+  auto out = std::back_inserter (sink);
+  auto result = puny_decoded (std::forward<Range> (range), out);
+  if (auto const* const decoded =
+        std::get_if<puny_decoded_result<decltype (out)>> (&result)) {
+    return decoded->any_encoded ? sink.size () : std::size_t{0};
+  }
+  if (auto const* const erc = std::get_if<std::error_code> (&result)) {
+    return *erc;
+  }
+  return make_error_code (std::errc::invalid_argument);
 }
 
 }  // end namespace details
@@ -199,9 +245,12 @@ template <typename VectorContainer>
   requires std::contiguous_iterator<typename VectorContainer::iterator> &&
            std::is_same_v<typename VectorContainer::value_type, char>
 parts encode (VectorContainer& store, parts const& p) {
+  using pft = std::underlying_type_t<parts_field>;
+  std::bitset<static_cast<pft> (parts_field::last)> needs_encoding;
+
   parts result = p;
   store.clear ();
-  auto convert_to_utf32 = [] (auto r) {
+  auto convert_to_utf32 = [] (auto const& r) {
     return r | std::views::transform ([] (char const c) {
              return static_cast<char8_t> (c);
            }) |
@@ -210,41 +259,119 @@ parts encode (VectorContainer& store, parts const& p) {
 
   auto required_size = std::size_t{0};
   details::parts_strings (
-    result, [&required_size, &convert_to_utf32] (std::string_view const str,
-                                                 parts_field const field) {
+    result, [&required_size, &convert_to_utf32, &needs_encoding] (
+              std::string_view const str, parts_field const field) {
       assert (str.data () != nullptr);
-      required_size += field == parts_field::host
-                         ? details::puny_encoded_size (convert_to_utf32 (str))
-                         : details::pct_encoded_size (
-                             str, pctencode_set_from_parts_field (field));
+      auto const extra = field == parts_field::host
+                           ? details::puny_encoded_size (convert_to_utf32 (str))
+                           : details::pct_encoded_size (
+                               str, pctencode_set_from_parts_field (field));
+      assert (static_cast<std::size_t> (field) < needs_encoding.size ());
+      auto const pos = static_cast<pft> (field);
+      needs_encoding.set (pos, needs_encoding.test (pos) || extra != 0);
+      required_size += extra;
       return str;
     });
   store.reserve (required_size);
 
+  details::parts_strings (result, [&store, &convert_to_utf32, &needs_encoding] (
+                                    std::string_view const str,
+                                    parts_field const field) {
+    assert (str.data () != nullptr);
+    assert (static_cast<std::size_t> (field) < needs_encoding.size ());
+    if (!needs_encoding.test (static_cast<pft> (field))) {
+      return str;
+    }
+
+    auto const original_size = store.size ();
+    if (field == parts_field::host) {
+      assert (details::puny_encoded_size (convert_to_utf32 (str)) != 0);
+      assert (store.capacity () >= original_size + details::puny_encoded_size (
+                                                     convert_to_utf32 (str)) &&
+              "store capacity is insufficient");
+      details::puny_encoded (convert_to_utf32 (str),
+                             std::back_inserter (store));
+      assert (original_size +
+                details::puny_encoded_size (convert_to_utf32 (str)) ==
+              store.size ());
+    } else {
+      auto const es = pctencode_set_from_parts_field (field);
+      assert (field == parts_field::path || needs_pctencode (str, es));
+      if (field == parts_field::path && !needs_pctencode (str, es)) {
+        return str;
+      }
+      assert (store.capacity () >=
+                original_size + details::pct_encoded_size (str, es) &&
+              "store capacity is insufficient");
+      pctencode (std::begin (str), std::end (str), std::back_inserter (store),
+                 es);
+      assert (original_size + details::pct_encoded_size (str, es) ==
+              store.size ());
+    }
+    return std::string_view{store.data () + original_size,
+                            store.size () - original_size};
+  });
+  assert (required_size == store.size () &&
+          "Expected store required size does not match actual");
+  return result;
+}
+
+template <typename VectorContainer>
+  requires std::contiguous_iterator<typename VectorContainer::iterator> &&
+           std::is_same_v<typename VectorContainer::value_type, char>
+std::variant<std::error_code, parts> decode (VectorContainer& store,
+                                             parts const& p) {
+  using pft = std::underlying_type_t<parts_field>;
+  std::bitset<static_cast<pft> (parts_field::last)> needs_encoding;
+
+  parts result = p;
+  store.clear ();
+
+  auto required_size = std::size_t{0};
+  std::error_code error;
   details::parts_strings (
-    result, [&store, &convert_to_utf32] (std::string_view const str,
-                                         parts_field const field) {
+    result, [&required_size, &error, &needs_encoding] (
+              std::string_view const str, parts_field const field) {
       assert (str.data () != nullptr);
+      if (error) {
+        return str;
+      }
+      auto extra = std::size_t{0};
+      if (field == parts_field::host) {
+        auto const pds_result = details::puny_decoded_size (str);
+        if (auto const* const size = std::get_if<std::size_t> (&pds_result)) {
+          extra = *size;
+        } else if (auto const* const erc =
+                     std::get_if<std::error_code> (&pds_result)) {
+          error = *erc;
+        } else {
+          error = make_error_code (std::errc::invalid_argument);
+        }
+      } else {
+        extra = details::pct_decoded_size (str);
+      }
+      needs_encoding.set (static_cast<pft> (field), extra != 0);
+      required_size += extra;
+      return str;
+    });
+  store.reserve (required_size);
+  if (error) {
+    return error;
+  }
+
+  details::parts_strings (
+    result, [&store, &needs_encoding] (std::string_view const str,
+                                       parts_field const field) {
+      assert (str.data () != nullptr);
+      assert (static_cast<std::size_t> (field) < needs_encoding.size ());
+      if (!needs_encoding.test (static_cast<pft> (field))) {
+        return str;
+      }
       auto const original_size = store.size ();
       if (field == parts_field::host) {
-        auto const pes = details::puny_encoded_size (convert_to_utf32 (str));
-        if (pes == 0) {
-          return str;
-        }
-        assert (store.capacity () >= original_size + pes &&
-                "store capacity is insufficient");
-        details::puny_encoded (convert_to_utf32 (str),
-                               std::back_inserter (store));
+        details::puny_decoded (str, std::back_inserter (store));
       } else {
-        auto const es = pctencode_set_from_parts_field (field);
-        if (!needs_pctencode (str, es)) {
-          return str;
-        }
-        assert (store.capacity () >=
-                  original_size + details::pct_encoded_size (str, es) &&
-                "store capacity is insufficient");
-        pctencode (std::begin (str), std::end (str), std::back_inserter (store),
-                   es);
+        std::ranges::copy (str | views::pctdecode, std::back_inserter (store));
       }
       return std::string_view{store.data () + original_size,
                               store.size () - original_size};

--- a/include/uri/parts.hpp
+++ b/include/uri/parts.hpp
@@ -1,0 +1,259 @@
+//===- include/uri/parts.hpp ------------------------------*- mode: C++ -*-===//
+//*                            *
+//*  _ __   __ _ _ __| |_ ___  *
+//* | '_ \ / _` | '__| __/ __| *
+//* | |_) | (_| | |  | |_\__ \ *
+//* | .__/ \__,_|_|   \__|___/ *
+//* |_|                        *
+//===----------------------------------------------------------------------===//
+// Distributed under the MIT License.
+// See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+// SPDX-License-Identifier: MIT
+//===----------------------------------------------------------------------===//
+#ifndef URI_PARTS_HPP
+#define URI_PARTS_HPP
+
+#include "uri/icubaby.hpp"
+#include "uri/pctencode.hpp"
+#include "uri/punycode.hpp"
+#include "uri/uri.hpp"
+
+namespace uri {
+
+enum class parts_field { scheme, userinfo, host, port, path, query, fragment };
+
+constexpr pctencode_set pctencode_set_from_parts_field (
+  parts_field const field) noexcept {
+  switch (field) {
+  case parts_field::userinfo: return pctencode_set::userinfo;
+  case parts_field::path: return pctencode_set::path;
+  case parts_field::query: return pctencode_set::query;
+  case parts_field::fragment: return pctencode_set::fragment;
+  case parts_field::host:
+  case parts_field::port:
+  case parts_field::scheme:
+  default: return pctencode_set::none;
+  }
+}
+
+namespace details {
+
+template <typename T>
+class ro_sink_container {
+public:
+  using value_type = T;
+
+  // NOLINTNEXTLINE(hicpp-named-parameter,readability-named-parameter)
+  constexpr void push_back (T const&) noexcept { ++size_; }
+  // NOLINTNEXTLINE(hicpp-named-parameter,readability-named-parameter)
+  constexpr void push_back (T&&) noexcept { ++size_; }
+  [[nodiscard]] constexpr std::size_t size () const noexcept { return size_; }
+  [[nodiscard]] constexpr bool empty () const noexcept { return size_ == 0; }
+
+private:
+  std::size_t size_ = 0;
+};
+
+std::size_t pct_encoded_size (std::string_view const str,
+                              pctencode_set const encodeset);
+
+template <typename Function>
+  requires std::is_invocable_r_v<std::string_view, Function, std::string_view,
+                                 parts_field>
+void parts_strings (parts& parts, Function const function) {
+  if (parts.scheme.has_value () && parts.scheme->data () != nullptr) {
+    parts.scheme = function (*parts.scheme, parts_field::scheme);
+  }
+  for (auto& segment : parts.path.segments) {
+    if (segment.data () != nullptr) {
+      segment = function (segment, parts_field::path);
+    }
+  }
+  if (parts.authority.has_value ()) {
+    auto& auth = *parts.authority;
+    if (auth.userinfo.has_value () && auth.userinfo->data () != nullptr) {
+      auth.userinfo = function (*auth.userinfo, parts_field::userinfo);
+    }
+    if (auth.host.data () != nullptr) {
+      auth.host = function (auth.host, parts_field::host);
+    }
+    if (auth.port.has_value () && auth.port->data () != nullptr) {
+      auth.port = function (*auth.port, parts_field::port);
+    }
+  }
+  if (parts.query.has_value () && parts.query->data () != nullptr) {
+    parts.query = function (*parts.query, parts_field::query);
+  }
+  if (parts.fragment.has_value () && parts.fragment->data () != nullptr) {
+    parts.fragment = function (*parts.fragment, parts_field::fragment);
+  }
+}
+
+template <std::output_iterator<char8_t> OutputIterator>
+struct puny_encoded_result {
+  OutputIterator out;
+  bool any_non_ascii = false;
+};
+
+constexpr inline bool is_not_dot (char32_t const code_point) {
+  return code_point != '.';
+}
+
+inline constexpr auto punycode_prefix = std::string_view{"xn--"};
+
+template <std::ranges::input_range Range,
+          std::output_iterator<char> OutputIterator>
+  requires std::is_same_v<std::remove_cv_t<std::ranges::range_value_t<Range>>,
+                          char32_t>
+puny_encoded_result<OutputIterator> puny_encoded (Range&& range,
+                                                  OutputIterator out) {
+  using std::ranges::subrange;
+  bool any_needed = false;
+  auto const end = std::ranges::end (range);
+
+  auto const find_dot = std::views::take_while (is_not_dot);
+  auto view = subrange{std::ranges::begin (range), end} | find_dot;
+
+  for (;;) {
+    std::string segment;
+    auto const& [in, _, any_non_ascii] =
+      punycode::encode (view, true, std::back_inserter (segment));
+    if (any_non_ascii) {
+      out = std::ranges::copy (punycode_prefix, out).out;
+      any_needed = true;
+    }
+    out = std::ranges::copy (segment, out).out;
+    if (in == end) {
+      break;
+    }
+
+    (*out++) = '.';
+    view = subrange{std::next (in), end} | find_dot;
+  }
+
+  return {std::move (out), any_needed};
+}
+
+template <std::ranges::bidirectional_range Range,
+          std::output_iterator<char32_t> OutputIterator>
+  requires std::is_same_v<std::ranges::range_value_t<Range>, char>
+std::error_code puny_decoded (Range&& range, OutputIterator out) {
+  using namespace std::string_view_literals;
+  using std::ranges::subrange;
+  auto const end = std::ranges::end (range);
+
+  auto const find_dot = std::views::take_while (is_not_dot);
+  auto view = subrange{std::ranges::begin (range), end} | find_dot;
+
+  for (;;) {
+    if (starts_with (view, punycode_prefix)) {
+      auto b = std::ranges::begin (view);
+      std::ranges::advance (b, punycode_prefix.size ());
+
+      auto const component = subrange{b, std::ranges::end (view)};
+      std::string str2;
+      std::ranges::copy (component, std::back_inserter (str2));
+
+      auto const decode_res = punycode::decode (str2);
+      if (auto const* erc = std::get_if<std::error_code> (&decode_res)) {
+        return *erc;
+      }
+      auto const& [_, out_] =
+        std::ranges::copy (std::get<std::u32string> (decode_res), out);
+      out = std::move (out_);
+
+      std::ranges::advance (b, str2.size () + 1);
+      auto in = b;
+      if (in == end) {
+        break;
+      }
+      view = subrange{in, end} | find_dot;
+    } else {
+      auto const& [in, out_] = std::ranges::copy (view, out);
+      out = out_;
+      if (in == end) {
+        break;
+      }
+      view = subrange{std::next (in), end} | find_dot;
+    }
+
+    (*out++) = '.';
+  }
+
+  return {};
+}
+
+template <std::ranges::input_range Range>
+  requires std::is_same_v<
+    std::remove_cv_t<typename std::ranges::range_value_t<Range>>, char32_t>
+std::size_t puny_encoded_size (Range&& range) {
+  details::ro_sink_container<char> sink;
+  return puny_encoded (range, std::back_inserter (sink)).any_non_ascii
+           ? sink.size ()
+           : std::size_t{0};
+}
+
+}  // end namespace details
+
+template <typename VectorContainer>
+  requires std::contiguous_iterator<typename VectorContainer::iterator> &&
+           std::is_same_v<typename VectorContainer::value_type, char>
+parts encode (VectorContainer& store, parts const& p) {
+  parts result = p;
+  store.clear ();
+  auto convert_to_utf32 = [] (auto r) {
+    return r | std::views::transform ([] (char const c) {
+             return static_cast<char8_t> (c);
+           }) |
+           icubaby::views::transcode<char8_t, char32_t>;
+  };
+
+  auto required_size = std::size_t{0};
+  details::parts_strings (
+    result, [&required_size, &convert_to_utf32] (std::string_view const str,
+                                                 parts_field const field) {
+      assert (str.data () != nullptr);
+      required_size += field == parts_field::host
+                         ? details::puny_encoded_size (convert_to_utf32 (str))
+                         : details::pct_encoded_size (
+                             str, pctencode_set_from_parts_field (field));
+      return str;
+    });
+  store.reserve (required_size);
+
+  details::parts_strings (
+    result, [&store, &convert_to_utf32] (std::string_view const str,
+                                         parts_field const field) {
+      assert (str.data () != nullptr);
+      auto const original_size = store.size ();
+      if (field == parts_field::host) {
+        auto const pes = details::puny_encoded_size (convert_to_utf32 (str));
+        if (pes == 0) {
+          return str;
+        }
+        assert (store.capacity () >= original_size + pes &&
+                "store capacity is insufficient");
+        details::puny_encoded (convert_to_utf32 (str),
+                               std::back_inserter (store));
+      } else {
+        auto const es = pctencode_set_from_parts_field (field);
+        if (!needs_pctencode (str, es)) {
+          return str;
+        }
+        assert (store.capacity () >=
+                  original_size + details::pct_encoded_size (str, es) &&
+                "store capacity is insufficient");
+        pctencode (std::begin (str), std::end (str), std::back_inserter (store),
+                   es);
+      }
+      return std::string_view{store.data () + original_size,
+                              store.size () - original_size};
+    });
+  assert (required_size == store.size () &&
+          "Expected store required size does not match actual");
+  return result;
+}
+
+}  // end namespace uri
+
+#endif  // URI_PARTS_HPP

--- a/include/uri/pctdecode.hpp
+++ b/include/uri/pctdecode.hpp
@@ -23,6 +23,11 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <version>
+
+#if !defined(__cpp_lib_ranges) || __cpp_lib_ranges < 202110L
+#error "Need __cpp_lib_ranges to be available"
+#endif
 
 namespace uri {
 
@@ -123,7 +128,7 @@ private:
   [[no_unique_address]] View base_ = View{};
 };
 
-template <class Range>
+template <typename Range>
 pctdecode_view (Range&&) -> pctdecode_view<std::views::all_t<Range>>;
 
 template <std::ranges::input_range View>

--- a/include/uri/pctdecode.hpp
+++ b/include/uri/pctdecode.hpp
@@ -25,8 +25,10 @@
 #include <utility>
 #include <version>
 
-#if !defined(__cpp_lib_ranges) || __cpp_lib_ranges < 202110L
+#if !defined(__cpp_lib_ranges)
 #error "Need __cpp_lib_ranges to be available"
+#elif __cpp_lib_ranges < 201911L
+#error "Need __cpp_lib_ranges to __cpp_lib_ranges >= 201911L"
 #endif
 
 namespace uri {

--- a/include/uri/pctdecode.hpp
+++ b/include/uri/pctdecode.hpp
@@ -16,24 +16,13 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <concepts>
 #include <cstddef>
 #include <iterator>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
-
-#if __has_include(<version>)
-#include <version>
-#endif
-
-#if defined(__cpp_concepts) && defined(__cpp_lib_concepts)
-#include <concepts>
-#endif
-
-#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201811L
-#include <ranges>
-#define URI_PCTDECODE_RANGES
-#endif
 
 namespace uri {
 
@@ -44,12 +33,7 @@ inline constexpr std::byte bad = std::byte{0b1'0000};
 /// Convert the argument character from a hexadecimal character code
 /// (A-F/a-f/0-9) to an integer in the range 0-15. If the input character is
 /// not a valid hex character code, returns uri::bad.
-#if defined(__cpp_concepts) && defined(__cpp_lib_concepts)
 template <std::integral ValueT>
-#else
-template <typename ValueT,
-          typename = std::enable_if_t<std::is_integral_v<ValueT>>>
-#endif
 constexpr std::byte hex2dec (ValueT const digit) noexcept {
   if (digit >= 'a' && digit <= 'f') {
     return static_cast<std::byte> (static_cast<unsigned> (digit) - ('a' - 10));
@@ -98,16 +82,11 @@ ReferenceType deref (Iterator pos, Iterator end, ValueType* const hex) {
 
 }  // end namespace details
 
-#if defined(__cpp_concepts) && defined(__cpp_lib_concepts)
 template <std::input_iterator InputIterator>
-#else
-template <typename InputIterator>
-#endif
 bool needs_pctdecode (InputIterator first, InputIterator last) {
   return std::find_if (first, last, [] (auto c) { return c == '%'; }) != last;
 }
 
-#ifdef URI_PCTDECODE_RANGES
 template <std::ranges::input_range View>
   requires std::ranges::forward_range<View>
 class pctdecode_view
@@ -259,8 +238,6 @@ inline constexpr auto pctdecode = details::pctdecode_range_adaptor{};
 // std::views::transform([] (auto c) { return std::tolower (c); });
 }  // end namespace views
 
-#endif  // URI_PCTDECODE_RANGES
-
 /// pctdecode_iterator is a forward-iterator which will produce characters from
 /// a string-view instance. Each time that it encounters a percent character "%"
 /// followed by two hexadecimal digits, the hexadecimal value is decoded. For
@@ -289,11 +266,6 @@ public:
             "Comparing iterators that refer to different inputs");
     return pos_ == other.pos_ && end_ == other.end_;
   }
-#if __cplusplus < 202002L
-  constexpr bool operator!= (pctdecode_iterator const& other) const noexcept {
-    return !operator== (other);
-  }
-#endif
 
   reference operator* () const {
     return details::deref<reference> (pos_, end_, &hex_);

--- a/include/uri/portab.hpp
+++ b/include/uri/portab.hpp
@@ -1,0 +1,90 @@
+#ifndef URI_PORTAB_HPP
+#define URI_PORTAB_HPP
+
+#include <cstdint>
+#include <functional>
+
+#if __has_include(<version>)
+#include <version>
+#endif
+
+namespace uri {
+
+#if defined(__cpp_lib_ranges_starts_ends_with) && \
+  __cpp_lib_ranges_starts_ends_with >= 202106L
+inline constexpr auto starts_with = std::ranges::starts_with;
+#else
+struct starts_with_fn {
+  template <std::input_iterator I1, std::sentinel_for<I1> S1,
+            std::input_iterator I2, std::sentinel_for<I2> S2,
+            typename Pred = std::ranges::equal_to,
+            typename Proj1 = std::identity, typename Proj2 = std::identity>
+    requires std::indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  constexpr bool operator() (I1 first1, S1 last1, I2 first2, S2 last2,
+                             Pred pred = {}, Proj1 proj1 = {},
+                             Proj2 proj2 = {}) const {
+    return std::ranges::mismatch (std::move (first1), last1, std::move (first2),
+                                  last2, std::move (pred), std::move (proj1),
+                                  std::move (proj2))
+             .in2 == last2;
+  }
+
+  template <std::ranges::input_range R1, std::ranges::input_range R2,
+            typename Pred = std::ranges::equal_to,
+            typename Proj1 = std::identity, typename Proj2 = std::identity>
+    requires std::indirectly_comparable<std::ranges::iterator_t<R1>,
+                                        std::ranges::iterator_t<R2>, Pred,
+                                        Proj1, Proj2>
+  constexpr bool operator() (R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {},
+                             Proj2 proj2 = {}) const {
+    return (*this) (std::ranges::begin (r1), std::ranges::end (r1),
+                    std::ranges::begin (r2), std::ranges::end (r2),
+                    std::move (pred), std::move (proj1), std::move (proj2));
+  }
+};
+
+inline constexpr starts_with_fn starts_with{};
+#endif  // __cpp_lib_ranges_starts_ends_with
+
+#if defined(__cpp_lib_ranges_find_last) && __cpp_lib_ranges_find_last >= 202207L
+inline constexpr auto find_last = std::ranges::find_last;
+#else
+struct find_last_fn {
+  template <std::forward_iterator I, std::sentinel_for<I> S, class T,
+            class Proj = std::identity>
+    requires std::indirect_binary_predicate<std::ranges::equal_to,
+                                            std::projected<I, Proj>, T const*>
+  constexpr std::ranges::subrange<I> operator() (I first, S last,
+                                                 const T& value,
+                                                 Proj proj = {}) const {
+    // Note: if I is mere forward_iterator, we may only go from begin to end.
+    I found{};
+    for (; first != last; ++first) {
+      if (std::invoke (proj, *first) == value) {
+        found = first;
+      }
+    }
+
+    if (found == I{}) {
+      return {first, first};
+    }
+    return {found, std::ranges::next (found, last)};
+  }
+
+  template <std::ranges::forward_range R, class T, class Proj = std::identity>
+    requires std::indirect_binary_predicate<
+      std::ranges::equal_to, std::projected<std::ranges::iterator_t<R>, Proj>,
+      const T*>
+  constexpr std::ranges::borrowed_subrange_t<R> operator() (
+    R&& r, const T& value, Proj proj = {}) const {
+    return this->operator() (std::ranges::begin (r), std::ranges::end (r),
+                             value, std::ref (proj));
+  }
+};
+
+inline constexpr find_last_fn find_last;
+#endif  // __cpp_lib_ranges_find_last
+
+}  // end namespace uri
+
+#endif  // URI_PORTAB_HPP

--- a/include/uri/uri.hpp
+++ b/include/uri/uri.hpp
@@ -117,6 +117,7 @@ std::ostream& operator<< (std::ostream& os,
 std::ostream& operator<< (std::ostream& os, parts const& p);
 
 std::optional<parts> split (std::string_view in);
+std::optional<parts> split_reference (std::string_view in);
 
 parts join (parts const& base, parts const& reference, bool strict = true);
 std::optional<parts> join (std::string_view Base, std::string_view R,

--- a/lib/uri/CMakeLists.txt
+++ b/lib/uri/CMakeLists.txt
@@ -12,11 +12,15 @@
 #===----------------------------------------------------------------------===//
 set (URI_INCLUDE_DIR "${URI_ROOT}/include")
 add_library (uri STATIC
+    "${URI_INCLUDE_DIR}/uri/icubaby.hpp"
+    "${URI_INCLUDE_DIR}/uri/parts.hpp"
     "${URI_INCLUDE_DIR}/uri/pctdecode.hpp"
     "${URI_INCLUDE_DIR}/uri/pctencode.hpp"
+    "${URI_INCLUDE_DIR}/uri/portab.hpp"
     "${URI_INCLUDE_DIR}/uri/punycode.hpp"
     "${URI_INCLUDE_DIR}/uri/rule.hpp"
     "${URI_INCLUDE_DIR}/uri/uri.hpp"
+    parts.cpp
     pctencode.cpp
     punycode.cpp
     rule.cpp

--- a/lib/uri/parts.cpp
+++ b/lib/uri/parts.cpp
@@ -1,0 +1,34 @@
+//===- lib/uri/parts.cpp --------------------------------------------------===//
+//*                   _        *
+//*  _ __   __ _ _ __| |_ ___  *
+//* | '_ \ / _` | '__| __/ __| *
+//* | |_) | (_| | |  | |_\__ \ *
+//* | .__/ \__,_|_|   \__|___/ *
+//* |_|                        *
+//===----------------------------------------------------------------------===//
+// Distributed under the MIT License.
+// See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+// SPDX-License-Identifier: MIT
+//===----------------------------------------------------------------------===//
+#include "uri/parts.hpp"
+
+#include <concepts>
+#include <iterator>
+
+#include "uri/icubaby.hpp"
+#include "uri/pctencode.hpp"
+
+namespace uri::details {
+
+std::size_t pct_encoded_size (std::string_view const str,
+                              pctencode_set const encodeset) {
+  if (!uri::needs_pctencode (str, encodeset)) {
+    return std::size_t{0};
+  }
+  ro_sink_container<char> sink;
+  uri::pctencode (std::begin (str), std::end (str), std::back_inserter (sink),
+                  encodeset);
+  return sink.size ();
+}
+
+}  // end namespace uri::details

--- a/lib/uri/parts.cpp
+++ b/lib/uri/parts.cpp
@@ -16,6 +16,7 @@
 #include <iterator>
 
 #include "uri/icubaby.hpp"
+#include "uri/pctdecode.hpp"
 #include "uri/pctencode.hpp"
 
 namespace uri::details {
@@ -29,6 +30,13 @@ std::size_t pct_encoded_size (std::string_view const str,
   uri::pctencode (std::begin (str), std::end (str), std::back_inserter (sink),
                   encodeset);
   return sink.size ();
+}
+
+std::size_t pct_decoded_size (std::string_view const str) {
+  if (!uri::needs_pctdecode (str.begin (), str.end ())) {
+    return std::size_t{0};
+  }
+  return uri::pctdecode (str).size ();
 }
 
 }  // end namespace uri::details

--- a/lib/uri/punycode.cpp
+++ b/lib/uri/punycode.cpp
@@ -15,156 +15,22 @@
 #include <cstdint>
 #include <limits>
 
-namespace {
-
-/// \returns The numeric value of a basic code point (for use in representing
-///   integers) in the range 0 to base-1, or base if cp does not represent a
-///   value.
-constexpr unsigned decode_digit (std::uint_least8_t cp) noexcept {
-  constexpr auto alphabet_size = 26U;
-  if (cp >= '0' && cp <= '9') {
-    // Digits 0..9 represent values 26..35
-    return cp - ('0' - alphabet_size);
-  }
-  if (cp >= 'a') {
-    cp -= 'a' - 'A';  // Convert to upper case.
-  }
-  return (cp >= 'A' && cp <= 'Z') ? cp - 'A' : uri::punycode::details::base;
-}
-
-constexpr std::size_t clampk (std::size_t const k,
-                              std::size_t const bias) noexcept {
-  using uri::punycode::details::tmax;
-  using uri::punycode::details::tmin;
-  if (k <= bias) {
-    return tmin;
-  }
-  if (k >= bias + tmax) {
-    return tmax;
-  }
-  return k - bias;
-}
-
-// Decode a generalized variable-length integer.
-template <typename Iterator>
-std::variant<std::error_code, std::tuple<std::size_t, Iterator>> decode_vli (
-  Iterator first, Iterator last, std::size_t vli, std::size_t bias) {
-  static constexpr auto max = std::numeric_limits<std::size_t>::max ();
-  using uri::punycode::decode_error_code;
-  using uri::punycode::details::base;
-
-  auto w = std::size_t{1};
-  for (auto k = base;; k += base) {
-    if (first == last) {
-      return make_error_code (decode_error_code::bad_input);
-    }
-    auto const digit = decode_digit (static_cast<std::uint_least8_t> (*first));
-    assert (digit <= base);
-    ++first;
-
-    if (digit >= base) {
-      return make_error_code (decode_error_code::bad_input);
-    }
-    if (digit > (max - vli) / w) {
-      return make_error_code (decode_error_code::overflow);
-    }
-    vli += digit * w;
-    std::size_t const t = clampk (k, bias);
-    if (digit < t) {
-      break;
-    }
-    if (w > max / (base - t)) {
-      return make_error_code (decode_error_code::overflow);
-    }
-    w *= (base - t);
-  }
-  return std::make_tuple (vli, first);
-}
-
-}  // end anonymous namespace
-
 namespace uri::punycode {
 
 char const* error_category::name () const noexcept {
   return "punycode decode";
 }
 std::string error_category::message (int error) const {
-  auto const* m = "unknown error";
   switch (static_cast<decode_error_code> (error)) {
-  case decode_error_code::bad_input: m = "bad input"; break;
-  case decode_error_code::overflow: m = "overflow"; break;
-  case decode_error_code::none: m = "unknown error"; break;
+  case decode_error_code::bad_input: return "bad input";
+  case decode_error_code::overflow: return "overflow";
+  case decode_error_code::none: return "unknown error";
+  default: return "unknown error";
   }
-  return m;
 }
 std::error_code make_error_code (decode_error_code const e) {
   static error_category category;
   return {static_cast<int> (e), category};
-}
-
-decode_result decode (std::string_view const& input) {
-  std::u32string output;
-  static constexpr auto maxint =
-    std::numeric_limits<std::uint_least32_t>::max ();
-  using details::adapt;
-  using details::delimiter;
-  using details::initial_bias;
-  using details::initial_n;
-
-  // Find the end of the literal portion (if there is one) by scanning for the
-  // last delimiter.
-  auto rb = std::find (input.rbegin (), input.rend (), delimiter);
-  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
-  auto b = rb == input.rend () ? input.begin () : rb.base () - 1;
-  // Copy the plain ASCII part of the string to the output (if any).
-  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
-  for (auto pos = input.begin (); pos != b; ++pos) {
-    auto const code_point = static_cast<char32_t> (*pos);
-    if (!details::is_basic_code_point (code_point)) {
-      return make_error_code (decode_error_code::bad_input);
-    }
-    output.push_back (code_point);
-  }
-
-  // The main decoding loop.
-  auto n = initial_n;
-  auto i = std::size_t{0};
-  auto bias = initial_bias;
-  // Start just after the last delimiter if any basic code points were
-  // copied; start at the beginning otherwise. *in is the next character to be
-  // consumed.
-  // NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
-  auto in = b != input.begin () ? b + 1 : input.begin ();
-  while (in != input.end ()) {
-    // Decode a generalized variable-length integer into delta, which gets added
-    // to i. The overflow checking is easier if we increase i as we go, then
-    // subtract off its starting value at the end to obtain delta.
-    auto const decode_res = decode_vli (in, input.end (), i, bias);
-    static_assert (
-      std::is_same_v<std::error_code,
-                     std::remove_const_t<
-                       std::variant_alternative_t<0, decltype (decode_res)>>>);
-    if (auto const* err = std::get_if<std::error_code> (&decode_res)) {
-      return *err;
-    }
-    auto const old_vli = i;
-    auto output_length = output.length ();
-    std::tie (i, in) = std::get<1> (decode_res);
-    bias = adapt (i - old_vli, output_length + 1, old_vli == 0);
-
-    // i was supposed to wrap around from out+1 to 0, incrementing n each time,
-    // so we'll fix that now.
-    if (i / (output_length + 1) > maxint - n) {
-      return make_error_code (decode_error_code::overflow);
-    }
-    n += i / (output_length + 1);
-    i %= (output_length + 1);
-
-    // Insert n into the output at position i.
-    output.insert (i, std::size_t{1}, static_cast<char32_t> (n));
-    ++i;
-  }
-  return output;
 }
 
 }  // end namespace uri::punycode

--- a/unittests/uri/CMakeLists.txt
+++ b/unittests/uri/CMakeLists.txt
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: MIT
 #===----------------------------------------------------------------------===//
 add_executable (unittest
+  test_parts.cpp
   test_pctdecode.cpp
   test_pctencode.cpp
   test_punycode.cpp

--- a/unittests/uri/test_parts.cpp
+++ b/unittests/uri/test_parts.cpp
@@ -77,10 +77,11 @@ TEST (Parts, PunyEncodedSizeMuchenDe) {
 // NOLINTNEXTLINE
 TEST (Parts, PunyEncodedMunchenGrinningFace) {
   uri::parts p;
-  p.authority = (struct uri::parts::authority){
-    std::nullopt, "M\xC3\xBCnchen.\xF0\x9F\x98\x80"sv, std::nullopt};
+  using auth = struct uri::parts::authority;
+  p.authority =
+    auth{std::nullopt, "M\xC3\xBCnchen.\xF0\x9F\x98\x80"sv, std::nullopt};
   std::vector<char> store;
-  uri::parts encoded_parts = uri::encode (store, p);
+  uri::parts const encoded_parts = uri::encode (store, p);
   EXPECT_EQ (encoded_parts.authority->host, "xn--Mnchen-3ya.xn--e28h");
 }
 
@@ -126,9 +127,9 @@ TEST (Parts, PunyDecodedMuchenDe) {
 // NOLINTNEXTLINE
 TEST (Parts, AllSetButNothingToEncode) {
   uri::parts input;
+  using auth = struct uri::parts::authority;
   input.scheme = "https"sv;
-  input.authority =
-    (struct uri::parts::authority){"user"sv, "host"sv, "1234"sv};
+  input.authority = auth{"user"sv, "host"sv, "1234"sv};
   input.path.absolute = true;
   input.path.segments = std::vector<std::string_view>{"a"sv, "b"sv};
   input.query = "query"sv;
@@ -158,9 +159,9 @@ TEST (Parts, AllSetButNothingToEncode) {
 // NOLINTNEXTLINE
 TEST (Parts, EncodeDecode) {
   uri::parts original;
+  using auth = struct uri::parts::authority;
   original.scheme = "https"sv;
-  original.authority =
-    (struct uri::parts::authority){"user"sv, "M\xC3\xBCnchen.de"sv, "1234"sv};
+  original.authority = auth{"user"sv, "M\xC3\xBCnchen.de"sv, "1234"sv};
   original.path.absolute = true;
   original.path.segments = std::vector<std::string_view>{"~\xC2\xA1"sv};
   original.query = "a%b"sv;
@@ -193,6 +194,7 @@ TEST (Parts, EncodeDecode) {
 // NOLINTNEXTLINE
 TEST (Parts, EncodeDecodePunycodeTLD) {
   uri::parts original;
+  using auth = struct uri::parts::authority;
   original.scheme = "http"sv;
   // CYRILLIC SMALL LETTER IO
   // CYRILLIC SMALL LETTER ZHE
@@ -201,8 +203,7 @@ TEST (Parts, EncodeDecodePunycodeTLD) {
   //
   // CYRILLIC SMALL LETTER ER
   // CYRILLIC SMALL LETTER EF
-  original.authority =
-    (struct uri::parts::authority){std::nullopt, "ёжик.рф"sv, std::nullopt};
+  original.authority = auth{std::nullopt, "ёжик.рф"sv, std::nullopt};
 
   std::vector<char> encode_store;
   uri::parts const encoded = uri::encode (encode_store, original);
@@ -268,7 +269,7 @@ static void EncodeDecodeRoundTrip (parts_without_authority const& base,
 
     auto const& decoded = std::get<uri::parts> (decode_result);
     EXPECT_EQ (decoded.scheme, original.scheme);
-    ASSERT_EQ (decoded.authority, original.authority);
+    ASSERT_EQ (decoded.authority.has_value (), original.authority.has_value ());
     if (decoded.authority && original.authority) {
       EXPECT_EQ (decoded.authority->userinfo, original.authority->userinfo);
       EXPECT_EQ (decoded.authority->host, original.authority->host);

--- a/unittests/uri/test_parts.cpp
+++ b/unittests/uri/test_parts.cpp
@@ -1,0 +1,134 @@
+//===- unittests/uri/test_parts.cpp ---------------------------------------===//
+//*                   _        *
+//*  _ __   __ _ _ __| |_ ___  *
+//* | '_ \ / _` | '__| __/ __| *
+//* | |_) | (_| | |  | |_\__ \ *
+//* | .__/ \__,_|_|   \__|___/ *
+//* |_|                        *
+//===----------------------------------------------------------------------===//
+// Distributed under the MIT License.
+// See https://github.com/paulhuggett/uri/blob/main/LICENSE for information.
+// SPDX-License-Identifier: MIT
+//===----------------------------------------------------------------------===//
+
+#include <gmock/gmock.h>
+
+#include "uri/icubaby.hpp"
+#include "uri/parts.hpp"
+
+#if URI_FUZZTEST
+#include <fuzztest/fuzztest.h>
+#endif
+
+using namespace std::string_view_literals;
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedSizeNoNonAscii) {
+  EXPECT_EQ (uri::details::puny_encoded_size (
+               u8"a.b"sv | icubaby::views::transcode<char8_t, char32_t>),
+             std::size_t{0});
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedThreeParts) {
+  std::string output;
+  uri::details::puny_encoded (
+    u8"aaa.bbb.ccc"sv | icubaby::views::transcode<char8_t, char32_t>,
+    std::back_inserter (output));
+  EXPECT_EQ (output, "aaa.bbb.ccc");
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedMuchenDe) {
+  std::string output;
+  uri::details::puny_encoded (
+    u8"M\xC3\xBCnchen.de"sv | icubaby::views::transcode<char8_t, char32_t>,
+    std::back_inserter (output));
+  EXPECT_EQ (output, "xn--Mnchen-3ya.de");
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedMuchenDotGrinningFace) {
+  std::string output;
+  // M<U+00FC LATIN SMALL LETTER U WITH DIAERESIS>nchen.<U+03C0 greek small
+  // letter pi>
+  uri::details::puny_encoded (u8"M\xC3\xBCnchen.\xCF\x80"sv |
+                                icubaby::views::transcode<char8_t, char32_t>,
+                              std::back_inserter (output));
+  EXPECT_EQ (output, "xn--Mnchen-3ya.xn--1xa");
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedSizeMuchenDe) {
+  EXPECT_EQ (
+    uri::details::puny_encoded_size (
+      u8"M\xC3\xBCnchen.de"sv | icubaby::views::transcode<char8_t, char32_t>),
+    std::size_t{17});
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, EncodedMunchenGrinningFace) {
+  uri::parts p;
+  p.authority = (struct uri::parts::authority){
+    std::nullopt, "M\xC3\xBCnchen.\xF0\x9F\x98\x80"sv, std::nullopt};
+  std::vector<char> store;
+  uri::parts encoded_parts = uri::encode (store, p);
+  EXPECT_EQ (encoded_parts.authority->host, "xn--Mnchen-3ya.xn--e28h");
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, Decoded) {
+  std::u32string output;
+  auto const input = std::string_view{"aaa.bbb.ccc"};
+  std::error_code const erc =
+    uri::details::puny_decoded (input, std::back_inserter (output));
+  EXPECT_FALSE (erc) << "Error was: " << erc.message ();
+  EXPECT_THAT (
+    output, testing::ElementsAre (char32_t{'a'}, char32_t{'a'}, char32_t{'a'},
+                                  char32_t{'.'}, char32_t{'b'}, char32_t{'b'},
+                                  char32_t{'b'}, char32_t{'.'}, char32_t{'c'},
+                                  char32_t{'c'}, char32_t{'c'}));
+}
+
+// NOLINTNEXTLINE
+TEST (Puny, DecodedMuchenDe) {
+  std::u32string output;
+  auto const input = std::string_view{"xn--Mnchen-3ya.de"};
+  std::error_code const erc =
+    uri::details::puny_decoded (input, std::back_inserter (output));
+  EXPECT_FALSE (erc) << "Error was: " << erc.message ();
+
+  static constexpr auto latin_small_letter_u_with_diaresis = char32_t{0x00FC};
+  EXPECT_THAT (
+    output, testing::ElementsAre (
+              char32_t{'M'}, latin_small_letter_u_with_diaresis, char32_t{'n'},
+              char32_t{'c'}, char32_t{'h'}, char32_t{'e'}, char32_t{'n'},
+              char32_t{'.'}, char32_t{'d'}, char32_t{'e'}));
+}
+
+#if URI_FUZZTEST
+using opt_authority = std::optional<struct uri::parts::authority>;
+
+struct parts_without_authority {
+  std::optional<std::string> scheme;
+  struct uri::parts::path path;
+  std::optional<std::string> query;
+  std::optional<std::string> fragment;
+
+  [[nodiscard]] uri::parts as_parts (opt_authority&& auth) const {
+    // assert (!auth || auth->host.data () != nullptr);
+    return uri::parts{scheme, std::move (auth), path, query, fragment};
+  }
+};
+static void EncodeAndComposeValidAlwaysAgree (
+  parts_without_authority const& base, opt_authority&& auth) {
+  std::vector<char> store;
+  uri::parts const p = uri::encode (store, base.as_parts (std::move (auth)));
+  if (p.valid ()) {
+    std::string const str = uri::compose (p);
+    EXPECT_TRUE (uri::split (str).has_value ());
+  }
+}
+// NOLINTNEXTLINE
+FUZZ_TEST (Puny, EncodeAndComposeValidAlwaysAgree);
+#endif  // URI_FUZZTEST

--- a/unittests/uri/test_parts.cpp
+++ b/unittests/uri/test_parts.cpp
@@ -254,6 +254,22 @@ TEST (Parts, EncodeDecodePunycodeTLD) {
   ASSERT_FALSE (decoded.fragment.has_value ());
 }
 
+// NOLINTNEXTLINE
+TEST (Parts, DecodeBadPunycodeTLD) {
+  uri::parts encoded;
+  using auth = struct uri::parts::authority;
+  encoded.scheme = "http"sv;
+  encoded.authority = auth{std::nullopt, "xn--ё"sv, std::nullopt};
+
+  std::vector<char> decode_store;
+  std::variant<std::error_code, uri::parts> const decode_result =
+    uri::decode (decode_store, encoded);
+  ASSERT_TRUE (std::holds_alternative<std::error_code> (decode_result));
+
+  EXPECT_EQ (std::get<std::error_code> (decode_result),
+             make_error_code (uri::punycode::decode_error_code::bad_input));
+}
+
 #if URI_FUZZTEST
 
 using opt_authority = std::optional<struct uri::parts::authority>;

--- a/unittests/uri/test_parts.cpp
+++ b/unittests/uri/test_parts.cpp
@@ -49,9 +49,19 @@ TEST (Parts, PunyEncodedThreeParts) {
 // NOLINTNEXTLINE
 TEST (Parts, PunyEncodedMuchenDe) {
   std::string output;
-  uri::details::puny_encoded (
-    u8"M\xC3\xBCnchen.de"sv | icubaby::views::transcode<char8_t, char32_t>,
-    std::back_inserter (output));
+  std::u32string const input{
+    'M',
+    static_cast<char32_t> (
+      0x00FC),  // U+00FC LATIN SMALL LETTER U WITH DIAERESIS
+    'n',
+    'c',
+    'h',
+    'e',
+    'n',
+    '.',
+    'd',
+    'e'};
+  uri::details::puny_encoded (input, std::back_inserter (output));
   EXPECT_EQ (output, "xn--Mnchen-3ya.de");
 }
 
@@ -60,18 +70,37 @@ TEST (Parts, PunyEncodedMuchenDotGrinningFace) {
   std::string output;
   // M<U+00FC LATIN SMALL LETTER U WITH DIAERESIS>nchen.<U+03C0 greek small
   // letter pi>
-  uri::details::puny_encoded (u8"M\xC3\xBCnchen.\xCF\x80"sv |
-                                icubaby::views::transcode<char8_t, char32_t>,
-                              std::back_inserter (output));
+  std::u32string const input{
+    'M',
+    static_cast<char32_t> (
+      0x00FC),  // U+00FC LATIN SMALL LETTER U WITH DIAERESIS
+    'n',
+    'c',
+    'h',
+    'e',
+    'n',
+    '.',
+    static_cast<char32_t> (0x03C0),  // U+03C0 GREEK SMALL LETTER PI
+  };
+  uri::details::puny_encoded (input, std::back_inserter (output));
   EXPECT_EQ (output, "xn--Mnchen-3ya.xn--1xa");
 }
 
 // NOLINTNEXTLINE
 TEST (Parts, PunyEncodedSizeMuchenDe) {
-  EXPECT_EQ (
-    uri::details::puny_encoded_size (
-      u8"M\xC3\xBCnchen.de"sv | icubaby::views::transcode<char8_t, char32_t>),
-    std::size_t{17});
+  std::u32string const input{
+    'M',
+    static_cast<char32_t> (
+      0x00FC),  // U+00FC LATIN SMALL LETTER U WITH DIAERESIS
+    'n',
+    'c',
+    'h',
+    'e',
+    'n',
+    '.',
+    'd',
+    'e'};
+  EXPECT_EQ (uri::details::puny_encoded_size (input), std::size_t{17});
 }
 
 // NOLINTNEXTLINE

--- a/unittests/uri/test_pctdecode.cpp
+++ b/unittests/uri/test_pctdecode.cpp
@@ -83,6 +83,7 @@ static void PctDecodeNeverCrashes (std::string const& input) {
   std::copy (uri::pctdecode_begin (input), uri::pctdecode_end (input),
              std::back_inserter (out));
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (PctDecodeFuzz, PctDecodeNeverCrashes);
 
 #if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201811L
@@ -91,6 +92,7 @@ static void PctDecodeViewNeverCrashes (std::string const& input) {
   auto r = input | uri::views::pctdecode;
   std::ranges::copy (r, std::back_inserter (out));
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (PctDecodeFuzz, PctDecodeViewNeverCrashes);
 
 #endif  // __cpp_lib_ranges

--- a/unittests/uri/test_pctencode.cpp
+++ b/unittests/uri/test_pctencode.cpp
@@ -137,6 +137,7 @@ static auto AnyEncodeSet () {
      uri::pctencode_set::userinfo, uri::pctencode_set::component,
      uri::pctencode_set::form_urlencoded});
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (PctEncodeFuzz, EncodeNeverCrashes)
   .WithDomains (fuzztest::String (), AnyEncodeSet ());
 #endif  // URI_FUZZTEST
@@ -153,6 +154,7 @@ static void RoundTrip (std::string const& s, uri::pctencode_set encodeset) {
 
   EXPECT_THAT (out, testing::StrEq (s));
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (PctEncodeFuzz, RoundTrip)
   .WithDomains (fuzztest::String (), AnyEncodeSet ());
 #endif  // URI_FUZZTEST

--- a/unittests/uri/test_punycode.cpp
+++ b/unittests/uri/test_punycode.cpp
@@ -20,6 +20,8 @@
 
 using namespace std::string_view_literals;
 
+constexpr auto decoded_success_result_index = std::size_t{1};
+
 // NOLINTNEXTLINE
 TEST (Punycode, AsciiNoPlain) {
   auto const orig = std::u32string{
@@ -30,8 +32,19 @@ TEST (Punycode, AsciiNoPlain) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  static_assert (
+    std::is_same_v<
+      uri::punycode::decode_success_result<
+        std::ranges::iterator_t<std::remove_const_t<decltype (encoded)>>>,
+      std::variant_alternative_t<decoded_success_result_index,
+                                 std::remove_const_t<decltype (decoded)>>>);
+
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -57,16 +70,25 @@ TEST (Punycode, Delimiter) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
 TEST (Punycode, DecodeDelimiterCaps) {
   constexpr auto batak_letter_a = char32_t{0x1BC0};
   auto const orig = std::u32string{',', '-', batak_letter_a};
-  EXPECT_EQ (uri::punycode::decode (",--9CR"sv),
-             uri::punycode::decode_result{orig});
+
+  auto const encoded = ",--9CR"sv;
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -79,8 +101,12 @@ TEST (Punycode, ArabicEgyptian) {
   std::string actual;
   uri::punycode::encode (arabic, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded_arabic);
-  EXPECT_EQ (uri::punycode::decode (encoded_arabic),
-             (uri::punycode::decode_result{arabic}));
+
+  auto const decoded = uri::punycode::decode (encoded_arabic);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, arabic);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded_arabic));
 }
 
 // NOLINTNEXTLINE
@@ -93,8 +119,13 @@ TEST (Punycode, ChineseSimplified) {
   uri::punycode::encode (chinese_simplified, false,
                          std::back_inserter (actual));
   EXPECT_EQ (actual, encoded_chinese_simplified);
-  EXPECT_EQ (uri::punycode::decode (encoded_chinese_simplified),
-             uri::punycode::decode_result{chinese_simplified});
+
+  auto const decoded = uri::punycode::decode (encoded_chinese_simplified);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str,
+             chinese_simplified);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded_chinese_simplified));
 }
 
 // NOLINTNEXTLINE
@@ -105,8 +136,12 @@ TEST (Punycode, ChineseTraditional) {
   auto const encoded = "ihqwctvzc91f659drss3x8bo0yb"sv;
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -120,8 +155,12 @@ TEST (Punycode, Czech) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -134,8 +173,12 @@ TEST (Punycode, Hebrew) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -149,8 +192,12 @@ TEST (Punycode, HindiDevanagari) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -162,8 +209,12 @@ TEST (Punycode, JapaneseKanjiAndHiragana) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -177,8 +228,12 @@ TEST (Punycode, KoreanHangulSyllables) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -192,8 +247,12 @@ TEST (Punycode, RussianCyrillic) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -209,8 +268,12 @@ TEST (Punycode, Spanish) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -226,8 +289,12 @@ TEST (Punycode, Vietnamese) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -239,8 +306,12 @@ TEST (Punycode, ExampleL) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -254,8 +325,12 @@ TEST (Punycode, ExampleM) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -269,8 +344,12 @@ TEST (Punycode, ExampleN) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -282,8 +361,12 @@ TEST (Punycode, ExampleO) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -296,8 +379,12 @@ TEST (Punycode, ExampleP) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -309,8 +396,12 @@ TEST (Punycode, ExampleQ) {
   std::string actual;
   uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -324,8 +415,12 @@ TEST (Punycode, ExampleR) {
     uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_TRUE (has_non_basic);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
@@ -339,22 +434,28 @@ TEST (Punycode, ExampleS) {
     uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_FALSE (has_non_basic);
-  EXPECT_EQ (uri::punycode::decode (encoded),
-             uri::punycode::decode_result{orig});
+
+  auto const decoded = uri::punycode::decode (encoded);
+  ASSERT_EQ (decoded.index (), decoded_success_result_index);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).str, orig);
+  EXPECT_EQ (std::get<decoded_success_result_index> (decoded).in,
+             std::end (encoded));
 }
 
 // NOLINTNEXTLINE
 TEST (Punycode, BadInput) {
-  EXPECT_EQ (uri::punycode::decode ("eg{|}"),
-             uri::punycode::decode_result{
-               make_error_code (uri::punycode::decode_error_code::bad_input)});
+  auto const decoded = uri::punycode::decode ("eg{|}");
+  ASSERT_EQ (decoded.index (), 0U);
+  EXPECT_EQ (std::get<0U> (decoded),
+             make_error_code (uri::punycode::decode_error_code::bad_input));
 }
 
 // NOLINTNEXTLINE
 TEST (Punycode, BadInputInPlainAsciiPart) {
-  EXPECT_EQ (uri::punycode::decode ("\x80-eg"),
-             uri::punycode::decode_result{
-               make_error_code (uri::punycode::decode_error_code::bad_input)});
+  auto const decoded = uri::punycode::decode ("\x80-eg");
+  ASSERT_EQ (decoded.index (), 0U);
+  EXPECT_EQ (std::get<0U> (decoded),
+             make_error_code (uri::punycode::decode_error_code::bad_input));
 }
 
 #if URI_FUZZTEST

--- a/unittests/uri/test_punycode.cpp
+++ b/unittests/uri/test_punycode.cpp
@@ -18,21 +18,54 @@
 #include "fuzztest/fuzztest.h"
 #endif
 
+using namespace std::string_view_literals;
+
 // NOLINTNEXTLINE
-TEST (Punycode, Delimiter) {
-  auto const orig = std::u32string{0x002C, 0x002D, 0x1BC0};
-  auto const* const encoded = ",--9cr";
+TEST (Punycode, AsciiNoPlain) {
+  auto const orig = std::u32string{
+    0x0041,  // U+0041 LATIN CAPITAL LETTER A
+    0x0062,  // U+0062 LATIN SMALL LETTER B
+  };
+  auto const encoded = "Ab-"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
 }
 
 // NOLINTNEXTLINE
-TEST (Punycode, DelimiterCaps) {
-  auto const orig = std::u32string{0x002C, 0x002D, 0x1BC0};
-  EXPECT_EQ (uri::punycode::decode (",--9CR"),
+TEST (Punycode, AsciiWithPlainAllowed) {
+  auto const orig = std::u32string{
+    0x0041,  // U+0041 LATIN CAPITAL LETTER A
+    0x0062,  // U+0062 LATIN SMALL LETTER B
+  };
+  auto const encoded = "Ab"sv;
+  std::string actual;
+  uri::punycode::encode (orig, true, std::back_inserter (actual));
+  EXPECT_EQ (actual, encoded);
+}
+
+// NOLINTNEXTLINE
+TEST (Punycode, Delimiter) {
+  auto const orig = std::u32string{
+    0x002C,  // U+002C COMMA
+    0x002D,  // U+002D HYPHEN-MINUS
+    0x1BC0,  // U+01BC0 BATAK LETTER A
+  };
+  auto const encoded = ",--9cr"sv;
+  std::string actual;
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
+  EXPECT_EQ (actual, encoded);
+  EXPECT_EQ (uri::punycode::decode (encoded),
+             uri::punycode::decode_result{orig});
+}
+
+// NOLINTNEXTLINE
+TEST (Punycode, DecodeDelimiterCaps) {
+  constexpr auto batak_letter_a = char32_t{0x1BC0};
+  auto const orig = std::u32string{',', '-', batak_letter_a};
+  EXPECT_EQ (uri::punycode::decode (",--9CR"sv),
              uri::punycode::decode_result{orig});
 }
 
@@ -42,9 +75,9 @@ TEST (Punycode, ArabicEgyptian) {
   auto const arabic = std::u32string{
     0x0644, 0x064A, 0x0647, 0x0645, 0x0627, 0x0628, 0x062A, 0x0643, 0x0644,
     0x0645, 0x0648, 0x0634, 0x0639, 0x0631, 0x0628, 0x064A, 0x061F};
-  auto const* const encoded_arabic = "egbpdaj6bu4bxfgehfvwxn";
+  auto const encoded_arabic = "egbpdaj6bu4bxfgehfvwxn"sv;
   std::string actual;
-  uri::punycode::encode (arabic, std::back_inserter (actual));
+  uri::punycode::encode (arabic, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded_arabic);
   EXPECT_EQ (uri::punycode::decode (encoded_arabic),
              (uri::punycode::decode_result{arabic}));
@@ -55,9 +88,10 @@ TEST (Punycode, ChineseSimplified) {
   // Chinese (simplified)
   auto const chinese_simplified = std::u32string{
     0x4ED6, 0x4EEC, 0x4E3A, 0x4EC0, 0x4E48, 0x4E0D, 0x8BF4, 0x4E2D, 0x6587};
-  auto const* const encoded_chinese_simplified = "ihqwcrb4cv8a8dqg056pqjye";
+  auto const encoded_chinese_simplified = "ihqwcrb4cv8a8dqg056pqjye"sv;
   std::string actual;
-  uri::punycode::encode (chinese_simplified, std::back_inserter (actual));
+  uri::punycode::encode (chinese_simplified, false,
+                         std::back_inserter (actual));
   EXPECT_EQ (actual, encoded_chinese_simplified);
   EXPECT_EQ (uri::punycode::decode (encoded_chinese_simplified),
              uri::punycode::decode_result{chinese_simplified});
@@ -68,9 +102,9 @@ TEST (Punycode, ChineseTraditional) {
   // Chinese (traditional)
   auto const orig = std::u32string{0x4ED6, 0x5011, 0x7232, 0x4EC0, 0x9EBD,
                                    0x4E0D, 0x8AAA, 0x4E2D, 0x6587};
-  auto const* const encoded = "ihqwctvzc91f659drss3x8bo0yb";
+  auto const encoded = "ihqwctvzc91f659drss3x8bo0yb"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
 }
@@ -82,9 +116,9 @@ TEST (Punycode, Czech) {
     0x0050, 0x0072, 0x006F, 0x010D, 0x0070, 0x0072, 0x006F, 0x0073,
     0x0074, 0x011B, 0x006E, 0x0065, 0x006D, 0x006C, 0x0075, 0x0076,
     0x00ED, 0x010D, 0x0065, 0x0073, 0x006B, 0x0079};
-  auto const* const encoded = "Proprostnemluvesky-uyb24dma41a";
+  auto const encoded = "Proprostnemluvesky-uyb24dma41a"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -96,9 +130,9 @@ TEST (Punycode, Hebrew) {
     0x05DC, 0x05DE, 0x05D4, 0x05D4, 0x05DD, 0x05E4, 0x05E9, 0x05D5,
     0x05D8, 0x05DC, 0x05D0, 0x05DE, 0x05D3, 0x05D1, 0x05E8, 0x05D9,
     0x05DD, 0x05E2, 0x05D1, 0x05E8, 0x05D9, 0x05EA};
-  auto const* const encoded = "4dbcagdahymbxekheh6e0a7fei0b";
+  auto const encoded = "4dbcagdahymbxekheh6e0a7fei0b"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -111,9 +145,9 @@ TEST (Punycode, HindiDevanagari) {
     0x094D, 0x0926, 0x0940, 0x0915, 0x094D, 0x092F, 0x094B, 0x0902,
     0x0928, 0x0939, 0x0940, 0x0902, 0x092C, 0x094B, 0x0932, 0x0938,
     0x0915, 0x0924, 0x0947, 0x0939, 0x0948, 0x0902};
-  auto const* const encoded = "i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd";
+  auto const encoded = "i1baa7eci9glrd9b2ae1bj0hfcgg6iyaf8o0a1dig0cd"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -124,9 +158,9 @@ TEST (Punycode, JapaneseKanjiAndHiragana) {
   auto const orig = std::u32string{
     0x306A, 0x305C, 0x307F, 0x3093, 0x306A, 0x65E5, 0x672C, 0x8A9E, 0x3092,
     0x8A71, 0x3057, 0x3066, 0x304F, 0x308C, 0x306A, 0x3044, 0x306E, 0x304B};
-  auto const* const encoded = "n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa";
+  auto const encoded = "n8jok5ay5dzabd5bym9f0cm5685rrjetr6pdxa"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -138,10 +172,10 @@ TEST (Punycode, KoreanHangulSyllables) {
     0xC138, 0xACC4, 0xC758, 0xBAA8, 0xB4E0, 0xC0AC, 0xB78C, 0xB4E4,
     0xC774, 0xD55C, 0xAD6D, 0xC5B4, 0xB97C, 0xC774, 0xD574, 0xD55C,
     0xB2E4, 0xBA74, 0xC5BC, 0xB9C8, 0xB098, 0xC88B, 0xC744, 0xAE4C};
-  auto const* const encoded =
-    "989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c";
+  auto const encoded =
+    "989aomsvi5e83db1d2a355cv1e0vak1dwrv93d5xbh15a0dt30a5jpsd879ccm6fea98c"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -154,9 +188,9 @@ TEST (Punycode, RussianCyrillic) {
                    0x0435, 0x043E, 0x043D, 0x0438, 0x043D, 0x0435, 0x0433,
                    0x043E, 0x0432, 0x043E, 0x0440, 0x044F, 0x0442, 0x043F,
                    0x043E, 0x0440, 0x0443, 0x0441, 0x0441, 0x043A, 0x0438};
-  auto const* const encoded = "b1abfaaepdrnnbgefbadotcwatmq2g4l";
+  auto const encoded = "b1abfaaepdrnnbgefbadotcwatmq2g4l"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -171,9 +205,9 @@ TEST (Punycode, Spanish) {
     0x006D, 0x0070, 0x006C, 0x0065, 0x006D, 0x0065, 0x006E, 0x0074,
     0x0065, 0x0068, 0x0061, 0x0062, 0x006C, 0x0061, 0x0072, 0x0065,
     0x006E, 0x0045, 0x0073, 0x0070, 0x0061, 0x00F1, 0x006F, 0x006C};
-  auto const* const encoded = "PorqunopuedensimplementehablarenEspaol-fmd56a";
+  auto const encoded = "PorqunopuedensimplementehablarenEspaol-fmd56a"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -188,9 +222,9 @@ TEST (Punycode, Vietnamese) {
     0x006B, 0x0068, 0x00F4, 0x006E, 0x0067, 0x0074, 0x0068, 0x1EC3,
     0x0063, 0x0068, 0x1EC9, 0x006E, 0x00F3, 0x0069, 0x0074, 0x0069,
     0x1EBF, 0x006E, 0x0067, 0x0056, 0x0069, 0x1EC7, 0x0074};
-  auto const* const encoded = "TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g";
+  auto const encoded = "TisaohkhngthchnitingVit-kjcr8268qyxafd2f1b9g"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -201,9 +235,9 @@ TEST (Punycode, ExampleL) {
   // 3<nen>B<gumi><kinpachi><sensei>
   auto const orig = std::u32string{0x0033, 0x5E74, 0x0042, 0x7D44,
                                    0x91D1, 0x516B, 0x5148, 0x751F};
-  auto const* const encoded = "3B-ww4c5e180e575a65lsy2b";
+  auto const encoded = "3B-ww4c5e180e575a65lsy2b"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -216,9 +250,9 @@ TEST (Punycode, ExampleM) {
     0x5B89, 0x5BA4, 0x5948, 0x7F8E, 0x6075, 0x002D, 0x0077, 0x0069,
     0x0074, 0x0068, 0x002D, 0x0053, 0x0055, 0x0050, 0x0045, 0x0052,
     0x002D, 0x004D, 0x004F, 0x004E, 0x004B, 0x0045, 0x0059, 0x0053};
-  auto const* const encoded = "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n";
+  auto const encoded = "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -231,9 +265,9 @@ TEST (Punycode, ExampleN) {
     0x0048, 0x0065, 0x006C, 0x006C, 0x006F, 0x002D, 0x0041, 0x006E, 0x006F,
     0x0074, 0x0068, 0x0065, 0x0072, 0x002D, 0x0057, 0x0061, 0x0079, 0x002D,
     0x305D, 0x308C, 0x305E, 0x308C, 0x306E, 0x5834, 0x6240};
-  auto const* const encoded = "Hello-Another-Way--fc4qua05auwb3674vfr0b";
+  auto const encoded = "Hello-Another-Way--fc4qua05auwb3674vfr0b"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -244,9 +278,9 @@ TEST (Punycode, ExampleO) {
   // <hitotsu><yane><no><shita>2
   auto const orig = std::u32string{0x3072, 0x3068, 0x3064, 0x5C4B,
                                    0x6839, 0x306E, 0x4E0B, 0x0032};
-  auto const* const encoded = "2-u9tlzr9756bt3uc0v";
+  auto const encoded = "2-u9tlzr9756bt3uc0v"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -258,9 +292,9 @@ TEST (Punycode, ExampleP) {
   auto const orig =
     std::u32string{0x004D, 0x0061, 0x006A, 0x0069, 0x3067, 0x004B, 0x006F,
                    0x0069, 0x3059, 0x308B, 0x0035, 0x79D2, 0x524D};
-  auto const* const encoded = "MajiKoi5-783gue6qz075azm5e";
+  auto const encoded = "MajiKoi5-783gue6qz075azm5e"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -271,9 +305,9 @@ TEST (Punycode, ExampleQ) {
   //  <pafii>de<runba>
   auto const orig = std::u32string{0x30D1, 0x30D5, 0x30A3, 0x30FC, 0x0064,
                                    0x0065, 0x30EB, 0x30F3, 0x30D0};
-  auto const* const encoded = "de-jg4avhby1noc0d";
+  auto const encoded = "de-jg4avhby1noc0d"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
@@ -284,10 +318,12 @@ TEST (Punycode, ExampleR) {
   // <sono><supiido><de>
   auto const orig =
     std::u32string{0x305D, 0x306E, 0x30B9, 0x30D4, 0x30FC, 0x30C9, 0x3067};
-  auto const* const encoded = "d9juau41awczczp";
+  auto const encoded = "d9juau41awczczp"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  auto const [_1, _2, has_non_basic] =
+    uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
+  EXPECT_TRUE (has_non_basic);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
 }
@@ -296,12 +332,13 @@ TEST (Punycode, ExampleR) {
 TEST (Punycode, ExampleS) {
   // (S) -> $1.00 <-
   auto const orig =
-    std::u32string{0x002D, 0x003E, 0x0020, 0x0024, 0x0031, 0x002E,
-                   0x0030, 0x0030, 0x0020, 0x003C, 0x002D};
-  auto const* const encoded = "-> $1.00 <--";
+    std::u32string{'-', '>', ' ', '$', '1', '.', '0', '0', ' ', '<', '-'};
+  auto const encoded = "-> $1.00 <--"sv;
   std::string actual;
-  uri::punycode::encode (orig, std::back_inserter (actual));
+  auto const [_1, _2, has_non_basic] =
+    uri::punycode::encode (orig, false, std::back_inserter (actual));
   EXPECT_EQ (actual, encoded);
+  EXPECT_FALSE (has_non_basic);
   EXPECT_EQ (uri::punycode::decode (encoded),
              uri::punycode::decode_result{orig});
 }
@@ -323,13 +360,15 @@ TEST (Punycode, BadInputInPlainAsciiPart) {
 #if URI_FUZZTEST
 static void EncodeNeverCrashes (std::u32string const& s) {
   std::string actual;
-  uri::punycode::encode (s, std::back_inserter (actual));
+  uri::punycode::encode (s, false, std::back_inserter (actual));
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (Punycode, EncodeNeverCrashes);
 
 static void DecodeNeverCrashes (std::string const& s) {
   uri::punycode::decode (s);
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (Punycode, DecodeNeverCrashes);
 #endif  // URI_FUZZTEST
 
@@ -345,12 +384,13 @@ auto U32String () {
 }
 void EncodeDecodeRoundTrip (std::u32string const& s) {
   std::string encoded;
-  uri::punycode::encode (s, std::back_inserter (encoded));
+  uri::punycode::encode (s, false, std::back_inserter (encoded));
   EXPECT_EQ (uri::punycode::decode (encoded), uri::punycode::decode_result{s});
 }
 
 }  // end anonymous namespace
 
+// NOLINTNEXTLINE
 FUZZ_TEST (Punycode, EncodeDecodeRoundTrip).WithDomains (U32String ());
 #endif  // URI_FUZZTEST
 
@@ -368,7 +408,7 @@ void DecodeEncodeRoundTrip (std::string const& original) {
   uri::punycode::decode_result const res = uri::punycode::decode (original);
   if (auto const* const decoded = std::get_if<std::u32string> (&res)) {
     std::string encoded;
-    uri::punycode::encode (*decoded, std::back_inserter (encoded));
+    uri::punycode::encode (*decoded, false, std::back_inserter (encoded));
 
     auto const ascii_end = ascii_part_end (original);
     ASSERT_EQ (original.size (), encoded.size ());
@@ -383,5 +423,6 @@ void DecodeEncodeRoundTrip (std::string const& original) {
 
 }  // end anonymous namespace
 
+// NOLINTNEXTLINE
 FUZZ_TEST (Punycode, DecodeEncodeRoundTrip);
 #endif  // URI_FUZZTEST

--- a/unittests/uri/test_uri.cpp
+++ b/unittests/uri/test_uri.cpp
@@ -11,8 +11,6 @@
 // SPDX-License-Identifier: MIT
 //===----------------------------------------------------------------------===//
 
-#include "uri/uri.hpp"
-
 #include <algorithm>
 #include <numeric>
 
@@ -21,12 +19,14 @@
 #endif
 
 // google test
-#include "gmock/gmock.h"
+#include <gmock/gmock.h>
 #if URI_FUZZTEST
-#include "fuzztest/fuzztest.h"
+#include <fuzztest/fuzztest.h>
 #endif
 
+#include "uri/parts.hpp"
 #include "uri/pctencode.hpp"
+#include "uri/uri.hpp"
 
 // to address
 // ~~~~~~~~~~
@@ -69,7 +69,7 @@ using namespace std::string_view_literals;
 
 // NOLINTNEXTLINE
 TEST (UriSplit, Empty) {
-  std::optional<uri::parts> const x = uri::split ("");
+  std::optional<uri::parts> const x = uri::split_reference ("");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->scheme);
   EXPECT_FALSE (x->authority);
@@ -80,7 +80,7 @@ TEST (UriSplit, Empty) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, EmptyPathComponents) {
-  std::optional<uri::parts> const x = uri::split ("/foo///bar");
+  std::optional<uri::parts> const x = uri::split_reference ("/foo///bar");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->scheme);
   EXPECT_FALSE (x->authority);
@@ -92,7 +92,8 @@ TEST (UriSplit, EmptyPathComponents) {
 
 // NOLINTNEXTLINE
 TEST (UriSplit, 0001) {
-  auto const x = uri::split ("C://[::A:eE5c]:2194/&///@//:_/%aB//.////#");
+  auto const x =
+    uri::split_reference ("C://[::A:eE5c]:2194/&///@//:_/%aB//.////#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "C");
   ASSERT_TRUE (x->authority);
@@ -110,7 +111,7 @@ TEST (UriSplit, 0001) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0002) {
-  auto const x = uri::split ("P-.:/?/?");
+  auto const x = uri::split_reference ("P-.:/?/?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "P-.");
   EXPECT_FALSE (x->authority);
@@ -121,7 +122,7 @@ TEST (UriSplit, 0002) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0003) {
-  auto const x = uri::split ("i+V:?");
+  auto const x = uri::split_reference ("i+V:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "i+V");
   EXPECT_FALSE (x->authority);
@@ -132,7 +133,7 @@ TEST (UriSplit, 0003) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0004) {
-  auto const x = uri::split ("L:%Cf#%dD/?H");
+  auto const x = uri::split_reference ("L:%Cf#%dD/?H");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "L");
   EXPECT_FALSE (x->authority);
@@ -146,7 +147,8 @@ TEST (UriSplit, 0004) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0005) {
-  auto const x = uri::split ("E07:/8=-~%bF//%36////'/%16N%78//)/%53/;?*!");
+  auto const x =
+    uri::split_reference ("E07:/8=-~%bF//%36////'/%16N%78//)/%53/;?*!");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "E07");
   EXPECT_FALSE (x->authority);
@@ -159,7 +161,7 @@ TEST (UriSplit, 0005) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0006) {
-  auto const x = uri::split ("v:");
+  auto const x = uri::split_reference ("v:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "v");
   EXPECT_FALSE (x->authority);
@@ -170,7 +172,7 @@ TEST (UriSplit, 0006) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0007) {
-  auto const x = uri::split ("YXa:/#B");
+  auto const x = uri::split_reference ("YXa:/#B");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "YXa");
   EXPECT_FALSE (x->authority);
@@ -181,7 +183,7 @@ TEST (UriSplit, 0007) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0008) {
-  auto const x = uri::split ("n:/,+?$#(+!)D");
+  auto const x = uri::split_reference ("n:/,+?$#(+!)D");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "n");
   EXPECT_FALSE (x->authority);
@@ -192,7 +194,7 @@ TEST (UriSplit, 0008) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0009) {
-  auto const x = uri::split ("m:/?cJ");
+  auto const x = uri::split_reference ("m:/?cJ");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "m");
   EXPECT_FALSE (x->authority);
@@ -203,7 +205,7 @@ TEST (UriSplit, 0009) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0010) {
-  auto const x = uri::split ("zR:d/M/kx/s/GTl///SgA/?#");
+  auto const x = uri::split_reference ("zR:d/M/kx/s/GTl///SgA/?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "zR");
   EXPECT_FALSE (x->authority);
@@ -215,7 +217,7 @@ TEST (UriSplit, 0010) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0011) {
-  auto const x = uri::split ("t:W?p#");
+  auto const x = uri::split_reference ("t:W?p#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "t");
   EXPECT_FALSE (x->authority);
@@ -226,7 +228,7 @@ TEST (UriSplit, 0011) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0012) {
-  auto const x = uri::split ("QrIq:/#");
+  auto const x = uri::split_reference ("QrIq:/#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "QrIq");
   EXPECT_FALSE (x->authority);
@@ -237,7 +239,7 @@ TEST (UriSplit, 0012) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0013) {
-  auto const x = uri::split ("OuU:/?bZK");
+  auto const x = uri::split_reference ("OuU:/?bZK");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "OuU");
   EXPECT_FALSE (x->authority);
@@ -248,7 +250,7 @@ TEST (UriSplit, 0013) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0014) {
-  auto const x = uri::split ("Fjfe:?h");
+  auto const x = uri::split_reference ("Fjfe:?h");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Fjfe");
   EXPECT_FALSE (x->authority);
@@ -259,7 +261,7 @@ TEST (UriSplit, 0014) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0015) {
-  auto const x = uri::split ("y:w/o/b/?lKTF");
+  auto const x = uri::split_reference ("y:w/o/b/?lKTF");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "y");
   EXPECT_FALSE (x->authority);
@@ -270,7 +272,7 @@ TEST (UriSplit, 0015) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0016) {
-  auto const x = uri::split ("P://=:_%bb%Cf%2F-8;~@230.109.31.250#.");
+  auto const x = uri::split_reference ("P://=:_%bb%Cf%2F-8;~@230.109.31.250#.");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "P");
   ASSERT_TRUE (x->authority);
@@ -284,7 +286,7 @@ TEST (UriSplit, 0016) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0017) {
-  auto const x = uri::split ("N://@=i%bD%Cb&*%Ea)%CE//:%cA//#?//");
+  auto const x = uri::split_reference ("N://@=i%bD%Cb&*%Ea)%CE//:%cA//#?//");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "N");
   ASSERT_TRUE (x->authority.has_value ());
@@ -300,7 +302,7 @@ TEST (UriSplit, 0017) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0018) {
-  auto const x = uri::split ("X:#");
+  auto const x = uri::split_reference ("X:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "X");
   EXPECT_FALSE (x->authority);
@@ -311,7 +313,7 @@ TEST (UriSplit, 0018) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0019) {
-  auto const x = uri::split ("U:??");
+  auto const x = uri::split_reference ("U:??");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "U");
   EXPECT_FALSE (x->authority);
@@ -322,7 +324,7 @@ TEST (UriSplit, 0019) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0020) {
-  auto const x = uri::split ("G:");
+  auto const x = uri::split_reference ("G:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "G");
   EXPECT_FALSE (x->authority);
@@ -333,7 +335,7 @@ TEST (UriSplit, 0020) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0021) {
-  auto const x = uri::split ("l6+:?#");
+  auto const x = uri::split_reference ("l6+:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "l6+");
   EXPECT_FALSE (x->authority);
@@ -344,7 +346,7 @@ TEST (UriSplit, 0021) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0022) {
-  auto const x = uri::split ("T.-://:@[VD.~]:?/@#");
+  auto const x = uri::split_reference ("T.-://:@[VD.~]:?/@#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "T.-");
   ASSERT_TRUE (x->authority.has_value ());
@@ -358,7 +360,7 @@ TEST (UriSplit, 0022) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0023) {
-  auto const x = uri::split ("rC://3.76.206.5:8966?/");
+  auto const x = uri::split_reference ("rC://3.76.206.5:8966?/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "rC");
   ASSERT_TRUE (x->authority.has_value ());
@@ -372,7 +374,7 @@ TEST (UriSplit, 0023) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0024) {
-  auto const x = uri::split ("oNP:///::");
+  auto const x = uri::split_reference ("oNP:///::");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "oNP");
   ASSERT_TRUE (x->authority.has_value ());
@@ -386,7 +388,7 @@ TEST (UriSplit, 0024) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0025) {
-  auto const x = uri::split ("g0:?#");
+  auto const x = uri::split_reference ("g0:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "g0");
   EXPECT_FALSE (x->authority);
@@ -397,7 +399,7 @@ TEST (UriSplit, 0025) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0026) {
-  auto const x = uri::split ("Do1-:");
+  auto const x = uri::split_reference ("Do1-:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Do1-");
   EXPECT_FALSE (x->authority);
@@ -408,7 +410,7 @@ TEST (UriSplit, 0026) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0027) {
-  auto const x = uri::split ("K:?");
+  auto const x = uri::split_reference ("K:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "K");
   EXPECT_FALSE (x->authority);
@@ -419,7 +421,7 @@ TEST (UriSplit, 0027) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0028) {
-  auto const x = uri::split ("tc://@[::F]:/::@~?@/");
+  auto const x = uri::split_reference ("tc://@[::F]:/::@~?@/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "tc");
   ASSERT_TRUE (x->authority.has_value ());
@@ -433,7 +435,7 @@ TEST (UriSplit, 0028) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0029) {
-  auto const x = uri::split ("N:#");
+  auto const x = uri::split_reference ("N:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "N");
   EXPECT_FALSE (x->authority);
@@ -444,7 +446,7 @@ TEST (UriSplit, 0029) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0030) {
-  auto const x = uri::split ("o:");
+  auto const x = uri::split_reference ("o:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "o");
   EXPECT_FALSE (x->authority);
@@ -455,7 +457,7 @@ TEST (UriSplit, 0030) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0031) {
-  auto const x = uri::split (R"(k-0+:???/)");
+  auto const x = uri::split_reference (R"(k-0+:???/)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "k-0+");
   EXPECT_FALSE (x->authority);
@@ -466,7 +468,8 @@ TEST (UriSplit, 0031) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0032) {
-  auto const x = uri::split (R"(y://%DD@253.216.255.251//aa/??/://;)");
+  auto const x =
+    uri::split_reference (R"(y://%DD@253.216.255.251//aa/??/://;)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "y");
   ASSERT_TRUE (x->authority.has_value ());
@@ -482,7 +485,8 @@ TEST (UriSplit, 0032) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0033) {
-  auto const x = uri::split ("B://.@[AC::1:6DEb:14.97.229.249]:?/#??~(");
+  auto const x =
+    uri::split_reference ("B://.@[AC::1:6DEb:14.97.229.249]:?/#??~(");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "B");
   ASSERT_TRUE (x->authority.has_value ());
@@ -496,7 +500,7 @@ TEST (UriSplit, 0033) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0034) {
-  auto const x = uri::split ("p://@26.254.86.252://aa");
+  auto const x = uri::split_reference ("p://@26.254.86.252://aa");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "p");
   ASSERT_TRUE (x->authority.has_value ());
@@ -512,7 +516,7 @@ TEST (UriSplit, 0034) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0035) {
-  auto const x = uri::split ("P+-n:#/%f0");
+  auto const x = uri::split_reference ("P+-n:#/%f0");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "P+-n");
   EXPECT_FALSE (x->authority);
@@ -523,7 +527,7 @@ TEST (UriSplit, 0035) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0036) {
-  auto const x = uri::split ("u:?");
+  auto const x = uri::split_reference ("u:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "u");
   EXPECT_FALSE (x->authority);
@@ -534,7 +538,7 @@ TEST (UriSplit, 0036) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0037) {
-  auto const x = uri::split ("U://%Aa:@[::b:E:A:53.48.69.41]?");
+  auto const x = uri::split_reference ("U://%Aa:@[::b:E:A:53.48.69.41]?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "U");
   ASSERT_TRUE (x->authority.has_value ());
@@ -548,7 +552,7 @@ TEST (UriSplit, 0037) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0038) {
-  auto const x = uri::split ("h.P+9:?:#?");
+  auto const x = uri::split_reference ("h.P+9:?:#?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "h.P+9");
   EXPECT_FALSE (x->authority);
@@ -559,7 +563,7 @@ TEST (UriSplit, 0038) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0039) {
-  auto const x = uri::split ("x:??#");
+  auto const x = uri::split_reference ("x:??#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "x");
   EXPECT_FALSE (x->authority);
@@ -570,7 +574,7 @@ TEST (UriSplit, 0039) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0040) {
-  auto const x = uri::split ("A:#");
+  auto const x = uri::split_reference ("A:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "A");
   EXPECT_FALSE (x->authority);
@@ -581,7 +585,7 @@ TEST (UriSplit, 0040) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0041) {
-  auto const x = uri::split ("Lp.:?#");
+  auto const x = uri::split_reference ("Lp.:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Lp.");
   EXPECT_FALSE (x->authority);
@@ -592,7 +596,7 @@ TEST (UriSplit, 0041) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0042) {
-  auto const x = uri::split ("d-:#");
+  auto const x = uri::split_reference ("d-:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "d-");
   EXPECT_FALSE (x->authority);
@@ -603,7 +607,7 @@ TEST (UriSplit, 0042) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0043) {
-  auto const x = uri::split ("h-.:?/?/#");
+  auto const x = uri::split_reference ("h-.:?/?/#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "h-.");
   EXPECT_FALSE (x->authority);
@@ -614,7 +618,7 @@ TEST (UriSplit, 0043) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0044) {
-  auto const x = uri::split ("d:");
+  auto const x = uri::split_reference ("d:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "d");
   EXPECT_FALSE (x->authority);
@@ -625,7 +629,7 @@ TEST (UriSplit, 0044) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0045) {
-  auto const x = uri::split ("L:");
+  auto const x = uri::split_reference ("L:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "L");
   EXPECT_FALSE (x->authority);
@@ -636,7 +640,7 @@ TEST (UriSplit, 0045) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0046) {
-  auto const x = uri::split ("Z5://@[9:BB:8:DAc:BbAA:E:a::]?#@$");
+  auto const x = uri::split_reference ("Z5://@[9:BB:8:DAc:BbAA:E:a::]?#@$");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Z5");
   ASSERT_TRUE (x->authority.has_value ());
@@ -650,7 +654,8 @@ TEST (UriSplit, 0046) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0047) {
-  auto const x = uri::split ("C-://[::1E:BB:a:5c1:Dd:40.44.228.108]/;?#");
+  auto const x =
+    uri::split_reference ("C-://[::1E:BB:a:5c1:Dd:40.44.228.108]/;?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "C-");
   ASSERT_TRUE (x->authority.has_value ());
@@ -664,7 +669,8 @@ TEST (UriSplit, 0047) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0048) {
-  auto const x = uri::split ("z://[c:BC:b:A:Bd:D:dC1f:cedB]?/#/:/%FA");
+  auto const x =
+    uri::split_reference ("z://[c:BC:b:A:Bd:D:dC1f:cedB]?/#/:/%FA");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "z");
   ASSERT_TRUE (x->authority.has_value ());
@@ -678,7 +684,7 @@ TEST (UriSplit, 0048) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0049) {
-  auto const x = uri::split ("x.2:#");
+  auto const x = uri::split_reference ("x.2:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "x.2");
   EXPECT_FALSE (x->authority);
@@ -689,7 +695,7 @@ TEST (UriSplit, 0049) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0050) {
-  auto const x = uri::split ("p://@[::F:e:4b:eCBE:f:c]");
+  auto const x = uri::split_reference ("p://@[::F:e:4b:eCBE:f:c]");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "p");
   ASSERT_TRUE (x->authority.has_value ());
@@ -703,7 +709,7 @@ TEST (UriSplit, 0050) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0051) {
-  auto const x = uri::split ("tmi://[e:C:Aa:eD::FDfD:b:F]:?");
+  auto const x = uri::split_reference ("tmi://[e:C:Aa:eD::FDfD:b:F]:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "tmi");
   ASSERT_TRUE (x->authority.has_value ());
@@ -717,7 +723,7 @@ TEST (UriSplit, 0051) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0052) {
-  auto const x = uri::split ("G+:");
+  auto const x = uri::split_reference ("G+:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "G+");
   EXPECT_FALSE (x->authority);
@@ -728,7 +734,8 @@ TEST (UriSplit, 0052) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0053) {
-  auto const x = uri::split ("A://[vA5.+:=.p~=)=&_;-=7)(.;]:768295/+");
+  auto const x =
+    uri::split_reference ("A://[vA5.+:=.p~=)=&_;-=7)(.;]:768295/+");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "A");
   ASSERT_TRUE (x->authority.has_value ());
@@ -742,7 +749,7 @@ TEST (UriSplit, 0053) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0054) {
-  auto const x = uri::split ("n+://[::]:9831#");
+  auto const x = uri::split_reference ("n+://[::]:9831#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "n+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -756,7 +763,7 @@ TEST (UriSplit, 0054) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0055) {
-  auto const x = uri::split ("v-2e.l:?:????:/");
+  auto const x = uri::split_reference ("v-2e.l:?:????:/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "v-2e.l");
   EXPECT_FALSE (x->authority);
@@ -767,7 +774,7 @@ TEST (UriSplit, 0055) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0056) {
-  auto const x = uri::split ("ka+://6.@[F::219.226.254.253]:900/'R#");
+  auto const x = uri::split_reference ("ka+://6.@[F::219.226.254.253]:900/'R#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "ka+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -781,7 +788,7 @@ TEST (UriSplit, 0056) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0057) {
-  auto const x = uri::split ("P://[daf::B:7:e:b:D:F]:730");
+  auto const x = uri::split_reference ("P://[daf::B:7:e:b:D:F]:730");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "P");
   ASSERT_TRUE (x->authority.has_value ());
@@ -795,7 +802,7 @@ TEST (UriSplit, 0057) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0058) {
-  auto const x = uri::split ("H://-!:_%Bd@[::]:7");
+  auto const x = uri::split_reference ("H://-!:_%Bd@[::]:7");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "H");
   ASSERT_TRUE (x->authority.has_value ());
@@ -809,7 +816,7 @@ TEST (UriSplit, 0058) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0059) {
-  auto const x = uri::split ("u+://;@[::dFC:d:6:d]://#");
+  auto const x = uri::split_reference ("u+://;@[::dFC:d:6:d]://#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "u+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -825,7 +832,7 @@ TEST (UriSplit, 0059) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0060) {
-  auto const x = uri::split ("D://[dCDa:c:e:B:F::D:a]:/%Dc");
+  auto const x = uri::split_reference ("D://[dCDa:c:e:B:F::D:a]:/%Dc");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "D");
   ASSERT_TRUE (x->authority.has_value ());
@@ -839,7 +846,7 @@ TEST (UriSplit, 0060) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0061) {
-  auto const x = uri::split ("mF2:");
+  auto const x = uri::split_reference ("mF2:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "mF2");
   EXPECT_FALSE (x->authority);
@@ -850,7 +857,8 @@ TEST (UriSplit, 0061) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0062) {
-  auto const x = uri::split ("f.://[d1b:CF:AbBa::F:d:11.246.155.253]?");
+  auto const x =
+    uri::split_reference ("f.://[d1b:CF:AbBa::F:d:11.246.155.253]?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "f.");
   ASSERT_TRUE (x->authority.has_value ());
@@ -864,7 +872,7 @@ TEST (UriSplit, 0062) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0063) {
-  auto const x = uri::split ("f5++://@[7d::6:df:f:245.95.78.9]:??");
+  auto const x = uri::split_reference ("f5++://@[7d::6:df:f:245.95.78.9]:??");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "f5++");
   ASSERT_TRUE (x->authority.has_value ());
@@ -878,7 +886,7 @@ TEST (UriSplit, 0063) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0064) {
-  auto const x = uri::split ("c.l://[::bba:B:6:1.255.161.3]:#?/");
+  auto const x = uri::split_reference ("c.l://[::bba:B:6:1.255.161.3]:#?/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "c.l");
   ASSERT_TRUE (x->authority.has_value ());
@@ -892,7 +900,7 @@ TEST (UriSplit, 0064) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0065) {
-  auto const x = uri::split ("T://[fdF::f2]");
+  auto const x = uri::split_reference ("T://[fdF::f2]");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "T");
   ASSERT_TRUE (x->authority.has_value ());
@@ -906,7 +914,7 @@ TEST (UriSplit, 0065) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0066) {
-  auto const x = uri::split ("U-92.://[::A:C:c]/");
+  auto const x = uri::split_reference ("U-92.://[::A:C:c]/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "U-92.");
   ASSERT_TRUE (x->authority.has_value ());
@@ -922,7 +930,7 @@ TEST (UriSplit, 0066) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0067) {
-  auto const x = uri::split ("K:?#");
+  auto const x = uri::split_reference ("K:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "K");
   EXPECT_FALSE (x->authority);
@@ -933,7 +941,7 @@ TEST (UriSplit, 0067) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0068) {
-  auto const x = uri::split ("l.://[c:CEa:cd1B:f:f:D::ef]?#%bC@/:");
+  auto const x = uri::split_reference ("l.://[c:CEa:cd1B:f:f:D::ef]?#%bC@/:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "l.");
   ASSERT_TRUE (x->authority.has_value ());
@@ -947,8 +955,8 @@ TEST (UriSplit, 0068) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0069) {
-  auto const x =
-    uri::split (R"(v+://@[::C:dEd:4:218.255.251.5]:8/@.;J??Q??%48/#)");
+  auto const x = uri::split_reference (
+    R"(v+://@[::C:dEd:4:218.255.251.5]:8/@.;J??Q??%48/#)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "v+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -962,7 +970,7 @@ TEST (UriSplit, 0069) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0070) {
-  auto const x = uri::split ("I:?#");
+  auto const x = uri::split_reference ("I:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "I");
   EXPECT_FALSE (x->authority);
@@ -973,7 +981,7 @@ TEST (UriSplit, 0070) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0071) {
-  auto const x = uri::split ("t.+://[::Ec:AcA:9a]:92/%8a/#");
+  auto const x = uri::split_reference ("t.+://[::Ec:AcA:9a]:92/%8a/#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "t.+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -989,7 +997,7 @@ TEST (UriSplit, 0071) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0072) {
-  auto const x = uri::split ("N+:?~");
+  auto const x = uri::split_reference ("N+:?~");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "N+");
   EXPECT_FALSE (x->authority);
@@ -1000,7 +1008,7 @@ TEST (UriSplit, 0072) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0073) {
-  auto const x = uri::split ("B:?/.#?");
+  auto const x = uri::split_reference ("B:?/.#?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "B");
   EXPECT_FALSE (x->authority);
@@ -1011,7 +1019,7 @@ TEST (UriSplit, 0073) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0074) {
-  auto const x = uri::split ("u8K.://.(@[d::Baa:dE:D]#/");
+  auto const x = uri::split_reference ("u8K.://.(@[d::Baa:dE:D]#/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "u8K.");
   ASSERT_TRUE (x->authority.has_value ());
@@ -1025,7 +1033,7 @@ TEST (UriSplit, 0074) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0075) {
-  auto const x = uri::split ("E+.://@[::F:ab79:B:fa:C]#");
+  auto const x = uri::split_reference ("E+.://@[::F:ab79:B:fa:C]#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "E+.");
   ASSERT_TRUE (x->authority.has_value ());
@@ -1039,7 +1047,7 @@ TEST (UriSplit, 0075) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0076) {
-  auto const x = uri::split ("S+://[::BBc:d0:EA:3.67.149.137]:/?#/");
+  auto const x = uri::split_reference ("S+://[::BBc:d0:EA:3.67.149.137]:/?#/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "S+");
   ASSERT_TRUE (x->authority.has_value ());
@@ -1056,7 +1064,8 @@ TEST (UriSplit, 0076) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0077) {
-  auto const x = uri::split (R"(Y://[4Bbc:bb::cDcd:5:c4:e:B1]:/%CA@/./??)");
+  auto const x =
+    uri::split_reference (R"(Y://[4Bbc:bb::cDcd:5:c4:e:B1]:/%CA@/./??)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Y");
   ASSERT_TRUE (x->authority.has_value ());
@@ -1073,7 +1082,7 @@ TEST (UriSplit, 0077) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0078) {
-  auto const x = uri::split ("W.-://[CF::]://!?");
+  auto const x = uri::split_reference ("W.-://[CF::]://!?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "W.-");
   ASSERT_TRUE (x->authority.has_value ());
@@ -1090,7 +1099,7 @@ TEST (UriSplit, 0078) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0079) {
-  auto const x = uri::split ("SF6:#");
+  auto const x = uri::split_reference ("SF6:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "SF6");
   EXPECT_FALSE (x->authority);
@@ -1101,7 +1110,7 @@ TEST (UriSplit, 0079) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0080) {
-  auto const x = uri::split (R"(R:?????////???/////#??@?_:?)");
+  auto const x = uri::split_reference (R"(R:?????////???/////#??@?_:?)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "R");
   EXPECT_FALSE (x->authority);
@@ -1112,7 +1121,7 @@ TEST (UriSplit, 0080) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0081) {
-  auto const x = uri::split ("g:");
+  auto const x = uri::split_reference ("g:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "g");
   EXPECT_FALSE (x->authority);
@@ -1123,7 +1132,7 @@ TEST (UriSplit, 0081) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0082) {
-  auto const x = uri::split (R"(D-ir+.PA:??#)");
+  auto const x = uri::split_reference (R"(D-ir+.PA:??#)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "D-ir+.PA");
   EXPECT_FALSE (x->authority);
@@ -1134,7 +1143,7 @@ TEST (UriSplit, 0082) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0083) {
-  auto const x = uri::split ("Z-.-:");
+  auto const x = uri::split_reference ("Z-.-:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Z-.-");
   EXPECT_FALSE (x->authority);
@@ -1145,7 +1154,7 @@ TEST (UriSplit, 0083) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0084) {
-  auto const x = uri::split ("y-:");
+  auto const x = uri::split_reference ("y-:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "y-");
   EXPECT_FALSE (x->authority);
@@ -1156,7 +1165,7 @@ TEST (UriSplit, 0084) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0085) {
-  auto const x = uri::split ("p:?");
+  auto const x = uri::split_reference ("p:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "p");
   EXPECT_FALSE (x->authority);
@@ -1167,7 +1176,7 @@ TEST (UriSplit, 0085) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0086) {
-  auto const x = uri::split ("M:#*.");
+  auto const x = uri::split_reference ("M:#*.");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "M");
   EXPECT_FALSE (x->authority);
@@ -1178,7 +1187,7 @@ TEST (UriSplit, 0086) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0087) {
-  auto const x = uri::split ("I:?%ab#/.");
+  auto const x = uri::split_reference ("I:?%ab#/.");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "I");
   EXPECT_FALSE (x->authority);
@@ -1189,7 +1198,7 @@ TEST (UriSplit, 0087) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0088) {
-  auto const x = uri::split ("v6:#:?");
+  auto const x = uri::split_reference ("v6:#:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "v6");
   EXPECT_FALSE (x->authority);
@@ -1200,7 +1209,7 @@ TEST (UriSplit, 0088) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0089) {
-  auto const x = uri::split ("D:#");
+  auto const x = uri::split_reference ("D:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "D");
   EXPECT_FALSE (x->authority);
@@ -1211,7 +1220,7 @@ TEST (UriSplit, 0089) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0090) {
-  auto const x = uri::split ("e.:#");
+  auto const x = uri::split_reference ("e.:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "e.");
   EXPECT_FALSE (x->authority);
@@ -1222,7 +1231,7 @@ TEST (UriSplit, 0090) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0091) {
-  auto const x = uri::split ("L:?#");
+  auto const x = uri::split_reference ("L:?#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "L");
   EXPECT_FALSE (x->authority);
@@ -1233,7 +1242,7 @@ TEST (UriSplit, 0091) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0092) {
-  auto const x = uri::split ("g-:#");
+  auto const x = uri::split_reference ("g-:#");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "g-");
   EXPECT_FALSE (x->authority);
@@ -1244,7 +1253,7 @@ TEST (UriSplit, 0092) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0093) {
-  auto const x = uri::split ("H:");
+  auto const x = uri::split_reference ("H:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "H");
   EXPECT_FALSE (x->authority);
@@ -1255,7 +1264,7 @@ TEST (UriSplit, 0093) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0094) {
-  auto const x = uri::split (R"(K:??)");
+  auto const x = uri::split_reference (R"(K:??)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "K");
   EXPECT_FALSE (x->authority);
@@ -1266,7 +1275,7 @@ TEST (UriSplit, 0094) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0095) {
-  auto const x = uri::split (R"(c-:?#)");
+  auto const x = uri::split_reference (R"(c-:?#)");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "c-");
   EXPECT_FALSE (x->authority);
@@ -1277,7 +1286,7 @@ TEST (UriSplit, 0095) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0096) {
-  auto const x = uri::split ("Bw:?");
+  auto const x = uri::split_reference ("Bw:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "Bw");
   EXPECT_FALSE (x->authority);
@@ -1288,7 +1297,7 @@ TEST (UriSplit, 0096) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0097) {
-  auto const x = uri::split ("hC:?");
+  auto const x = uri::split_reference ("hC:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "hC");
   EXPECT_FALSE (x->authority);
@@ -1299,7 +1308,7 @@ TEST (UriSplit, 0097) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0098) {
-  auto const x = uri::split ("q:?/#/");
+  auto const x = uri::split_reference ("q:?/#/");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "q");
   EXPECT_FALSE (x->authority);
@@ -1310,7 +1319,7 @@ TEST (UriSplit, 0098) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0099) {
-  auto const x = uri::split ("L:");
+  auto const x = uri::split_reference ("L:");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "L");
   EXPECT_FALSE (x->authority);
@@ -1321,7 +1330,7 @@ TEST (UriSplit, 0099) {
 }
 // NOLINTNEXTLINE
 TEST (UriSplit, 0100) {
-  auto const x = uri::split ("W-:?");
+  auto const x = uri::split_reference ("W-:?");
   ASSERT_TRUE (x);
   EXPECT_EQ (x->scheme, "W-");
   EXPECT_FALSE (x->authority);
@@ -1335,12 +1344,13 @@ TEST (UriSplit, 0100) {
 static void UriSplitNeverCrashes (std::string const& input) {
   uri::split (input);
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (UriSplitFuzz, UriSplitNeverCrashes);
 #endif  // URI_FUZZTEST
 
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LeadingDotDotSlash) {
-  auto x = uri::split ("../bar");
+  auto x = uri::split_reference ("../bar");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("..", "bar"));
@@ -1349,7 +1359,7 @@ TEST (RemoveDotSegments, LeadingDotDotSlash) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LeadingDotSlash) {
-  auto x = uri::split ("./bar");
+  auto x = uri::split_reference ("./bar");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre (".", "bar"));
@@ -1358,7 +1368,7 @@ TEST (RemoveDotSegments, LeadingDotSlash) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LeadingDotDotSlashDotSlash) {
-  auto x = uri::split (".././bar");
+  auto x = uri::split_reference (".././bar");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("..", ".", "bar"));
@@ -1368,7 +1378,7 @@ TEST (RemoveDotSegments, LeadingDotDotSlashDotSlash) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, MidDot) {
-  auto x = uri::split ("/foo/./bar");
+  auto x = uri::split_reference ("/foo/./bar");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("foo", ".", "bar"));
@@ -1378,7 +1388,7 @@ TEST (RemoveDotSegments, MidDot) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LonelySlashDot) {
-  auto x = uri::split ("/.");
+  auto x = uri::split_reference ("/.");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("."));
@@ -1390,7 +1400,7 @@ TEST (RemoveDotSegments, LonelySlashDot) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, TrailingDotSlash) {
-  auto x = uri::split ("/bar/./");
+  auto x = uri::split_reference ("/bar/./");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("bar", ".", ""));
@@ -1402,7 +1412,7 @@ TEST (RemoveDotSegments, TrailingDotSlash) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, MidSlashDotDot) {
-  auto x = uri::split ("/foo/../bar");
+  auto x = uri::split_reference ("/foo/../bar");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("foo", "..", "bar"));
@@ -1414,7 +1424,7 @@ TEST (RemoveDotSegments, MidSlashDotDot) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, TrailingDotDotSlash) {
-  auto x = uri::split ("/bar/../");
+  auto x = uri::split_reference ("/bar/../");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("bar", "..", ""));
@@ -1426,7 +1436,7 @@ TEST (RemoveDotSegments, TrailingDotDotSlash) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LonelySlashDotDot) {
-  auto x = uri::split ("/..");
+  auto x = uri::split_reference ("/..");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre (".."));
@@ -1436,12 +1446,12 @@ TEST (RemoveDotSegments, LonelySlashDotDot) {
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre (""));
 
-  auto const x2 = uri::split ("/");
+  auto const x2 = uri::split_reference ("/");
   EXPECT_EQ (x, x2);
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, TrailingSlashDotDot) {
-  auto x = uri::split ("/bar/..");
+  auto x = uri::split_reference ("/bar/..");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("bar", ".."));
@@ -1451,12 +1461,12 @@ TEST (RemoveDotSegments, TrailingSlashDotDot) {
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre (""));
 
-  auto const x2 = uri::split ("/");
+  auto const x2 = uri::split_reference ("/");
   EXPECT_EQ (x, x2);
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, TwoDirectoriesTrailingSlashDotDot) {
-  auto x = uri::split ("/foo/bar/..");
+  auto x = uri::split_reference ("/foo/bar/..");
   ASSERT_TRUE (x);
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("foo", "bar", ".."));
@@ -1466,12 +1476,12 @@ TEST (RemoveDotSegments, TwoDirectoriesTrailingSlashDotDot) {
   EXPECT_TRUE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("foo", ""));
 
-  auto const x2 = uri::split ("/foo/");
+  auto const x2 = uri::split_reference ("/foo/");
   EXPECT_EQ (x, x2);
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LonelyDot) {
-  auto x = uri::split (".");
+  auto x = uri::split_reference (".");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("."));
@@ -1483,7 +1493,7 @@ TEST (RemoveDotSegments, LonelyDot) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LonelyDotDot) {
-  auto x = uri::split ("..");
+  auto x = uri::split_reference ("..");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre (".."));
@@ -1495,7 +1505,7 @@ TEST (RemoveDotSegments, LonelyDotDot) {
 }
 // NOLINTNEXTLINE
 TEST (RemoveDotSegments, LonelyDotDotSlashDot) {
-  auto x = uri::split ("../.");
+  auto x = uri::split_reference ("../.");
   ASSERT_TRUE (x);
   EXPECT_FALSE (x->path.absolute);
   EXPECT_THAT (x->path.segments, ElementsAre ("..", "."));
@@ -1636,29 +1646,6 @@ TEST_F (Join, Abnormal) {
   EXPECT_EQ (uri::split ("http:g"), uri::join (base_, "http:g"));
 }
 
-using authority = std::optional<struct uri::parts::authority>;
-struct parts_without_authority {
-  std::optional<std::string> scheme;
-  struct uri::parts::path path;
-  std::optional<std::string> query;
-  std::optional<std::string> fragment;
-
-  [[nodiscard]] uri::parts as_parts (
-    std::optional<struct uri::parts::authority> const& authority) const {
-    return uri::parts{scheme, authority, path, query, fragment};
-  }
-};
-#if URI_FUZZTEST
-static void UriJoinNeverCrashes (parts_without_authority const& base,
-                                 authority const& base_auth,
-                                 parts_without_authority const& reference,
-                                 authority const& reference_auth, bool strict) {
-  uri::join (base.as_parts (base_auth), reference.as_parts (reference_auth),
-             strict);
-}
-FUZZ_TEST (UriJoinFuzz, UriJoinNeverCrashes);
-#endif
-
 // NOLINTNEXTLINE
 TEST (UriCompose, Empty) {
   uri::parts p;
@@ -1679,7 +1666,7 @@ TEST (UriCompose, Authority) {
   p.authority->port = "123";
   auto const expected = "//username@host:123"sv;
   EXPECT_EQ (uri::compose (p), expected);
-  EXPECT_EQ (uri::split (expected), p);
+  EXPECT_EQ (uri::split_reference (expected), p);
 }
 // NOLINTNEXTLINE
 TEST (UriCompose, AbsolutePath) {
@@ -1690,7 +1677,7 @@ TEST (UriCompose, AbsolutePath) {
   p.path.segments.emplace_back ();
   auto const expected = "/a/b/"sv;
   EXPECT_EQ (uri::compose (p), expected);
-  EXPECT_EQ (uri::split (expected), p);
+  EXPECT_EQ (uri::split_reference (expected), p);
 }
 // NOLINTNEXTLINE
 TEST (UriCompose, RelativePath) {
@@ -1700,7 +1687,7 @@ TEST (UriCompose, RelativePath) {
   p.path.segments.emplace_back ();
   auto const expected = "a/b/"sv;
   EXPECT_EQ (uri::compose (p), expected);
-  EXPECT_EQ (uri::split (expected), p);
+  EXPECT_EQ (uri::split_reference (expected), p);
 }
 // NOLINTNEXTLINE
 TEST (UriCompose, Query) {
@@ -1708,7 +1695,7 @@ TEST (UriCompose, Query) {
   p.query = "query";
   auto const expected = "?query"sv;
   EXPECT_EQ (uri::compose (p), expected);
-  EXPECT_EQ (uri::split (expected), p);
+  EXPECT_EQ (uri::split_reference (expected), p);
 }
 // NOLINTNEXTLINE
 TEST (UriCompose, Fragment) {
@@ -1716,7 +1703,7 @@ TEST (UriCompose, Fragment) {
   p.fragment = "fragment";
   auto const expected = "#fragment"sv;
   EXPECT_EQ (uri::compose (p), expected);
-  EXPECT_EQ (uri::split (expected), p);
+  EXPECT_EQ (uri::split_reference (expected), p);
 }
 // NOLINTNEXTLINE
 TEST (UriCompose, EmptyStrings) {
@@ -1729,7 +1716,7 @@ TEST (UriCompose, EmptyStrings) {
   p.query = "";
   p.fragment = "";
   std::string const& c = uri::compose (p);
-  auto const& p2 = uri::split (c);
+  auto const& p2 = uri::split_reference (c);
   ASSERT_TRUE (p2);
   EXPECT_EQ (p, *p2);
 }
@@ -1741,225 +1728,41 @@ static void SplitComposeEqual (std::string const& s) {
     EXPECT_EQ (s2, s);
   }
 }
+// NOLINTNEXTLINE
 FUZZ_TEST (UriCompose, SplitComposeEqual);
 #endif  // URI_FUZZTEST
 
 // NOLINTNEXTLINE
-TEST (PartsValid, Scheme) {
+TEST (PartsValid, SchemeEmpty) {
   uri::parts p;
-  EXPECT_TRUE (p.valid ());
+  EXPECT_FALSE (p.valid ()) << "Scheme must have at least one leading ALPHA";
+}
+
+TEST (PartsValid, SchemeSimple) {
+  uri::parts p;
   p.scheme = "scheme";
   EXPECT_TRUE (p.valid ());
+}
+
+TEST (PartsValid, SchemeLeadingDigit) {
+  uri::parts p;
   p.scheme = "123";
-  EXPECT_FALSE (p.valid ());
+  EXPECT_FALSE (p.valid ()) << "Scheme must have at least one leading ALPHA";
+}
+
+TEST (PartsValid, SchemeMixedCharacters) {
+  uri::parts p;
+  p.scheme = "a+123";
+  EXPECT_TRUE (p.valid ())
+    << R"!(scheme must be ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ))!";
 }
 
 // NOLINTNEXTLINE
 TEST (PartsValid, AuthorityUserinfo) {
   using parts_authority = struct uri::parts::authority;
   uri::parts p;
+  p.scheme = "scheme";
   p.authority = parts_authority{"userinfo"sv, "host"sv, std::nullopt};
   EXPECT_TRUE (p.valid ());
   EXPECT_EQ (p.valid (), uri::split (uri::compose (p)).has_value ());
 }
-
-template <typename T>
-class ro_sink_container {
-public:
-  using value_type = T;
-
-  // NOLINTNEXTLINE(hicpp-named-parameter,readability-named-parameter)
-  void push_back (T const&) noexcept { ++size_; }
-  // NOLINTNEXTLINE(hicpp-named-parameter,readability-named-parameter)
-  void push_back (T&&) noexcept { ++size_; }
-  [[nodiscard]] std::size_t size () const noexcept { return size_; }
-  [[nodiscard]] bool empty () const noexcept { return size_ == 0; }
-
-private:
-  std::size_t size_ = 0;
-};
-
-static std::size_t pct_encoded_size (std::string_view s,
-                                     uri::pctencode_set encodeset) {
-  if (!uri::needs_pctencode (s, encodeset)) {
-    return 0;
-  }
-  ro_sink_container<char> c;
-  uri::pctencode (std::begin (s), std::end (s), std::back_inserter (c),
-                  encodeset);
-  return c.size ();
-}
-
-template <typename Function>
-void parts_strings (uri::parts & p, Function f) {
-  if (p.scheme.has_value ()) {
-    p.scheme = f (*p.scheme, uri::pctencode_set::none);
-  }
-  for (auto & segment: p.path.segments) {
-    segment = f (segment, uri::pctencode_set::path);
-  }
-  if (p.authority.has_value()) {
-    auto & auth = *p.authority;
-    if (auth.userinfo.has_value ()) {
-      auth.userinfo = f (*auth.userinfo, uri::pctencode_set::userinfo);
-    }
-    auth.host = f (auth.host, uri::pctencode_set::none);
-    if (auth.port.has_value ()) {
-      auth.port = f (*auth.port, uri::pctencode_set::none);
-    }
-  }
-  if (p.query.has_value ()) {
-    p.query = f (*p.query, uri::pctencode_set::query);
-  }
-  if (p.fragment.has_value ()) {
-    p.fragment = f (*p.fragment, uri::pctencode_set::fragment);
-  }
-}
-
-static uri::parts encode (std::vector<char> & store, uri::parts const & p) {
-  uri::parts result = p;
-  store.clear ();
-
-  std::size_t size = 0;
-  parts_strings (result, [&size] (std::string_view s, uri::pctencode_set es) {
-    size += pct_encoded_size (s, es);
-    return s;
-  });
-  store.reserve (size);
-  parts_strings (result, [&store] (std::string_view s, uri::pctencode_set es) {
-    if (!uri::needs_pctencode (s, es)) {
-      return s;
-    }
-    auto first = std::end (store);
-    uri::pctencode (std::begin (s), std::end (s), std::back_inserter (store),
-                    es);
-    auto last = std::end (store);
-    auto const dist = std::distance (first, last);
-    assert (dist > 0);
-    return std::string_view{to_address (first),
-                            static_cast<std::string_view::size_type> (dist)};
-  });
-  assert (store.size () == size);
-  return result;
-}
-
-// NOLINTNEXTLINE
-TEST (UriCompose, SplitAndValidAgree) {
-  parts_without_authority base;
-  authority auth;
-  std::vector<char> store;
-  uri::parts const p = encode (store, base.as_parts (auth));
-  std::string const str = uri::compose (p);
-  EXPECT_EQ (p.valid (), uri::split (str).has_value ());
-}
-
-#if 0  // URI_FUZZTEST
-static void SplitAndValidAlwaysAgree (parts_without_authority const& base,
-                                      authority const& auth) {
-  std::vector<char> store;
-  uri::parts const p = encode (store, base.as_parts (auth));
-  std::string const str = uri::compose (p);
-  EXPECT_EQ (p.valid (), uri::split (str).has_value ());
-}
-FUZZ_TEST (UriPartsValid, SplitAndValidAlwaysAgree);
-#endif  // URI_FUZZTEST
-
-#if 0
-static std::size_t pct_decoded_size (std::string_view s) {
-  if (!uri::needs_pctdecode (std::begin (s), std::end (s))) {
-    return 0;
-  }
-  auto b = uri::pctdecode_begin(s);
-  using difference_type = std::iterator_traits<decltype(b)>::difference_type;
-  auto dist = std::distance (b, uri::pctdecode_end (s));
-  assert (dist >= 0);
-  return static_cast<std::size_t> (std::max (dist, difference_type{0}));
-}
-static uri::parts decode (std::vector<char> & store, uri::parts const & p) {
-  uri::parts result = p;
-  store.clear ();
-
-  std::size_t size = 0;
-  parts_strings (result, [&size] (std::string_view s) { size += pct_decoded_size (s); return s; });
-  store.reserve (size);
-  parts_strings (result, [&store] (std::string_view s) {
-    if (!uri::needs_pctdecode (std::begin (s), std::end (s))) {
-      return s;
-    }
-    auto first = std::end (store);
-    std::copy (uri::pctdecode_begin (s), uri::pctdecode_end (s), std::back_inserter (store));
-    auto last = std::end (store);
-    assert (std::distance (first, last) > 0);
-    return std::string_view{first, last};
-  });
-  assert (store.size () == size);
-  return result;
-}
-
-using osv = std::optional<std::string_view>;
-static void ComposeSplitEqual (osv const & scheme, std::vector<std::string> const & segments, bool has_authority, osv userinfo, std::string_view host, osv port, osv query, osv fragment) {
-  uri::parts p;
-  p.scheme = scheme;
-  p.path.absolute = true;
-  std::copy (std::begin (segments), std::end (segments), std::back_inserter (p.path.segments));
-  //  p.path.segments = segments;
-  if (has_authority) {
-    p.authority.emplace (userinfo, host, port);
-  }
-  p.query = query;
-  p.fragment = fragment;
-
-  std::vector<char> encoded_store;
-  uri::parts encoded_parts = encode (encoded_store, p);
-  std::string const & c = uri::compose(encoded_parts);
-  auto const & p2 = uri::split (c);
-
-  ASSERT_TRUE (p2) << "Can't split string " << c;
-  std::vector<char> decoded_store;
-  uri::parts decoded_parts = decode (decoded_store, *p2);
-  decoded_parts.path.absolute = true;
-
-
-  EXPECT_EQ (p.scheme, decoded_parts.scheme);
-  EXPECT_EQ (p.path.absolute, decoded_parts.path.absolute);
-  EXPECT_EQ (p.path.segments, decoded_parts.path.segments) << "From input " << encoded_parts << " to " << *p2;
-  EXPECT_EQ (p.authority.has_value(), decoded_parts.authority.has_value());
-  if (p.authority && decoded_parts.authority) {
-    EXPECT_EQ (p.authority->userinfo, decoded_parts.authority->userinfo);
-    EXPECT_EQ (p.authority->host, decoded_parts.authority->host);
-    EXPECT_EQ (p.authority->port, decoded_parts.authority->port);
-  }
-  EXPECT_EQ (p.query, decoded_parts.query);
-  EXPECT_EQ (p.fragment, decoded_parts.fragment);
-  //EXPECT_EQ (p, decoded_parts);
-}
-
-static auto NonEmptyString () {
-  using fuzztest::StringOf;
-  using fuzztest::OneOf;
-  using fuzztest::PrintableAsciiChar;
-
-  return StringOf(OneOf(PrintableAsciiChar()));
-}
-using fuzztest::OptionalOf;
-using fuzztest::ContainerOf;
-using fuzztest::Arbitrary;
-using fuzztest::AsciiString;
-using fuzztest::StringOf;
-using fuzztest::NumericChar;
-using fuzztest::VectorOf;
-using fuzztest::PrintableAsciiString;
-using fuzztest::InRegexp;
-
-FUZZ_TEST (UriCompose, ComposeSplitEqual)
-  .WithDomains (
-		OptionalOf(InRegexp("[a-zA-Z][a-zA-Z0-9+-.]*")), // scheme  ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-		VectorOf(NonEmptyString()), //segments
-		Arbitrary<bool>(),
-		OptionalOf(PrintableAsciiString()), // userinfo
-		AsciiString(), // host
-		OptionalOf(StringOf(NumericChar())), //port
-		OptionalOf(Arbitrary<std::string_view>()), //query
-		OptionalOf(Arbitrary<std::string_view>()) // fragment
-    );
-#endif


### PR DESCRIPTION
The different components of the URL are encoded with percent-encoding or punycode-encoding. This new module knows which is which and encodes and decodes accordingly. It can determine the storage needed for any strings where encoding is necessary.

This change drops support for C++ 17.