### PR TITLE
Update the runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       BUILD_DIR: ./build_fuzztest
-      CLANG_VERSION: 16
+      CLANG_VERSION: 18
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/fuzztest.yaml
+++ b/.github/workflows/fuzztest.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   fuzztest:
     name: Fuzz Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       BUILD_DIR: ./build_fuzztest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set (URI_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (URI_FUZZTEST)
   set (FUZZTEST_FUZZING_MODE On)
-  set (FUZZTEST_REPO_BRANCH "HEAD" CACHE STRING "FuzzTest repository branch.")
+  set (FUZZTEST_REPO_BRANCH "release_2026-02-19" CACHE STRING "FuzzTest repository branch.")
   message ("Building fuzztest at tag " ${FUZZTEST_REPO_BRANCH})
   FetchContent_Declare (
     fuzztest


### PR DESCRIPTION
This is to resolve a problem building the fuzz-test workflow. An old version of ld throws an error due to unrecognised DWARF.